### PR TITLE
Add public YouTube playlist import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ How we cut releases: [docs/RELEASE.md](docs/RELEASE.md).
 ## [Unreleased]
 
 ### Added
+- Review-and-append import for public YouTube playlists, including pagination, duplicate detection, availability checks, and MYO capacity filtering.
 - yt-dlp download outcome logs (`ok` / `fail` / `escalate` / `coalesce`) so Railway logs show whether cookies recovered after bot checks.
 - In-process singleflight for concurrent downloads of the same YouTube id (preview stampede protection).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,6 +44,12 @@ Phone layout for the three-panel editor. On small screens YouTube result titles 
 
 Optional per-result toggle to expand YouTube chapters into separate playlist tracks. Must compose cleanly with auto ~1-hour long-track splitting.
 
+### First-class chapter and track editing
+
+Preserve Yoto’s nested playlist model in the editor: add, rename, reorder, and delete chapters; allow multiple tracks per chapter; and expose track end behavior where useful.
+
+Use [`@lizozom/yoto`](https://github.com/lizozom/yoto-cli) as an API/schema reference or evaluate its MIT-licensed library directly. Keep Louis’s browser PKCE session authoritative rather than shelling out to a host-installed CLI, so the feature also works in Docker.
+
 ### Desktop app wrapper (Electron or Tauri)
 
 Package Louis as a cross-OS executable so less technical users can run it without Docker/GitHub CLI — consumer-friendly install alongside the one-click hosting work.

--- a/app/components/myo-editor/useMyoEditor.ts
+++ b/app/components/myo-editor/useMyoEditor.ts
@@ -10,7 +10,10 @@ import {
   removePersistedSave,
 } from './saveJobPersistence'
 import type { SaveJobState, YotoCardDetail } from './types'
-import { getPlaylistPreflightLimitError } from '#shared/myo-editor/yotoMyoLimits'
+import {
+  getPlaylistPreflightLimitError,
+  getTrackCountLimitError,
+} from '#shared/myo-editor/yotoMyoLimits'
 
 export interface SaveProgress {
   phase: SaveJobState['status']
@@ -54,6 +57,7 @@ export interface MyoEditorContext {
   selectCard: (card: YotoMyoCard) => Promise<void>
   clearSelection: (force?: boolean) => boolean
   resetChanges: () => void
+  appendTracks: (tracks: PlaylistTrack[]) => { ok: true, added: number } | { ok: false, message: string }
   updateCard: (options?: { acknowledgeCapacityRisk?: boolean }) => Promise<void>
 }
 
@@ -500,6 +504,39 @@ export function useMyoEditor() {
     errorMessage.value = ''
   }
 
+  function appendTracks(
+    tracks: PlaylistTrack[],
+  ): { ok: true, added: number } | { ok: false, message: string } {
+    if (!selectedCardId.value) {
+      return { ok: false, message: 'Select a MYO card before importing a playlist.' }
+    }
+    if (loading.value || isPlaylistLocked.value) {
+      return { ok: false, message: 'Wait for the current card operation to finish.' }
+    }
+
+    const countError = getTrackCountLimitError(playlist.value.length + tracks.length)
+    if (countError) return { ok: false, message: countError }
+
+    const existingKeys = new Set(
+      playlist.value.map(track => track.youtubeId ? `youtube:${track.youtubeId}` : `track:${track.id}`),
+    )
+    const incomingKeys = new Set<string>()
+    for (const track of tracks) {
+      const key = track.youtubeId ? `youtube:${track.youtubeId}` : `track:${track.id}`
+      if (existingKeys.has(key) || incomingKeys.has(key)) {
+        return {
+          ok: false,
+          message: 'The playlist changed while you were reviewing it. Review duplicate tracks and try again.',
+        }
+      }
+      incomingKeys.add(key)
+    }
+
+    playlist.value = [...playlist.value, ...clonePlaylist(tracks)]
+    errorMessage.value = ''
+    return { ok: true, added: tracks.length }
+  }
+
   async function updateCard(options?: { acknowledgeCapacityRisk?: boolean }) {
     const cardId = selectedCardId.value
     if (!cardId || !isDirty.value || loading.value || isPlaylistLocked.value) return
@@ -557,6 +594,7 @@ export function useMyoEditor() {
     selectCard,
     clearSelection,
     resetChanges,
+    appendTracks,
     updateCard,
   }
 }

--- a/app/components/youtube-picker/YoutubePlaylistImport.vue
+++ b/app/components/youtube-picker/YoutubePlaylistImport.vue
@@ -1,0 +1,682 @@
+<script setup lang="ts">
+import { MYO_EDITOR_KEY } from '~/components/myo-editor/keys'
+import { pickerVideoToPlaylistTrack } from '~/components/playlist/types'
+import {
+  evaluateYoutubePlaylistImport,
+  parseYoutubePlaylistUrl,
+  preselectYoutubePlaylistImport,
+  type YoutubePlaylistImportBlockReason,
+  type YoutubePlaylistImportItem,
+  type YoutubePlaylistImportResponse,
+  type YoutubePlaylistSummary,
+} from '#shared/myo-editor/youtubePlaylistImport'
+import { formatDurationSeconds } from '#shared/myo-editor/youtubeDuration'
+
+const BLOCK_REASON_LABELS: Record<YoutubePlaylistImportBlockReason, string> = {
+  unavailable: 'Unavailable',
+  'missing-duration': 'Missing duration',
+  'over-track-duration': 'Over 60 minutes',
+  'duplicate-existing': 'Already on this card',
+  'duplicate-source': 'Repeated in source playlist',
+  'track-capacity': 'Card track limit',
+  'duration-capacity': 'Card time limit',
+}
+
+const editor = inject(MYO_EDITOR_KEY, null)
+const { allowLongTracks, setAllowLongTracks } = useUserPreferences()
+const { playEvent } = useUiSound()
+
+const open = ref(false)
+const url = ref('')
+const playlist = ref<YoutubePlaylistSummary | null>(null)
+const items = ref<YoutubePlaylistImportItem[]>([])
+const selectedKeys = ref(new Set<string>())
+const nextPageToken = ref<string | undefined>()
+const loading = ref(false)
+const loadingMore = ref(false)
+const appending = ref(false)
+const errorMessage = ref('')
+const pageErrorMessage = ref('')
+const inputRef = ref<HTMLInputElement | null>(null)
+
+const canOpen = computed(
+  () => Boolean(editor?.selectedCardId.value) && !editor?.isPlaylistLocked.value,
+)
+
+const evaluation = computed(() =>
+  evaluateYoutubePlaylistImport(
+    items.value,
+    editor?.playlist.value ?? [],
+    selectedKeys.value,
+    allowLongTracks.value,
+  ),
+)
+
+const selectedDurationLabel = computed(
+  () => formatDurationSeconds(evaluation.value.selectedDurationSeconds),
+)
+
+function resetImport() {
+  url.value = ''
+  playlist.value = null
+  items.value = []
+  selectedKeys.value = new Set()
+  nextPageToken.value = undefined
+  loading.value = false
+  loadingMore.value = false
+  appending.value = false
+  errorMessage.value = ''
+  pageErrorMessage.value = ''
+}
+
+async function show() {
+  if (!canOpen.value) {
+    playEvent('disabled')
+    return
+  }
+  resetImport()
+  open.value = true
+  playEvent('buttonClick')
+  await nextTick()
+  inputRef.value?.focus()
+}
+
+function close() {
+  if (loading.value || loadingMore.value || appending.value) return
+  open.value = false
+  playEvent('toggleOff')
+}
+
+function fetchErrorMessage(err: unknown, fallback: string): string {
+  const fetchErr = err as {
+    statusMessage?: string
+    data?: { message?: string, statusMessage?: string }
+    message?: string
+  }
+  return fetchErr.data?.message
+    ?? fetchErr.data?.statusMessage
+    ?? fetchErr.statusMessage
+    ?? fetchErr.message
+    ?? fallback
+}
+
+async function fetchPage(playlistId: string, pageToken?: string) {
+  return await $fetch<YoutubePlaylistImportResponse>('/api/youtube/playlist', {
+    query: { playlistId, pageToken },
+  })
+}
+
+async function loadPlaylist() {
+  const playlistId = parseYoutubePlaylistUrl(url.value)
+  if (!playlistId) {
+    errorMessage.value = 'Paste a full HTTPS YouTube playlist URL.'
+    return
+  }
+
+  loading.value = true
+  errorMessage.value = ''
+  pageErrorMessage.value = ''
+  playlist.value = null
+  items.value = []
+  selectedKeys.value = new Set()
+  nextPageToken.value = undefined
+
+  try {
+    const data = await fetchPage(playlistId)
+    playlist.value = data.playlist ?? null
+    items.value = data.items
+    nextPageToken.value = data.nextPageToken
+    selectedKeys.value = preselectYoutubePlaylistImport(
+      items.value,
+      editor?.playlist.value ?? [],
+      allowLongTracks.value,
+    ).selectedKeys
+    playEvent('loadMoreComplete')
+  }
+  catch (err: unknown) {
+    errorMessage.value = fetchErrorMessage(err, 'Failed to load YouTube playlist')
+  }
+  finally {
+    loading.value = false
+  }
+}
+
+async function loadMore() {
+  const playlistId = parseYoutubePlaylistUrl(url.value)
+  const token = nextPageToken.value
+  if (!playlistId || !token || loadingMore.value) return
+
+  loadingMore.value = true
+  pageErrorMessage.value = ''
+  try {
+    const data = await fetchPage(playlistId, token)
+    const requested = new Set(selectedKeys.value)
+    for (const item of data.items) requested.add(item.playlistItemId)
+    items.value = [...items.value, ...data.items]
+    nextPageToken.value = data.nextPageToken
+    selectedKeys.value = evaluateYoutubePlaylistImport(
+      items.value,
+      editor?.playlist.value ?? [],
+      requested,
+      allowLongTracks.value,
+    ).selectedKeys
+    playEvent('loadMoreComplete')
+  }
+  catch (err: unknown) {
+    pageErrorMessage.value = fetchErrorMessage(err, 'Failed to load the next page')
+  }
+  finally {
+    loadingMore.value = false
+  }
+}
+
+function toggleItem(
+  playlistItemId: string,
+  selected: boolean,
+  blockReason?: YoutubePlaylistImportBlockReason,
+) {
+  if (blockReason && !selected) {
+    playEvent('disabled')
+    return
+  }
+
+  const requested = new Set(selectedKeys.value)
+  if (selected) requested.delete(playlistItemId)
+  else requested.add(playlistItemId)
+
+  selectedKeys.value = evaluateYoutubePlaylistImport(
+    items.value,
+    editor?.playlist.value ?? [],
+    requested,
+    allowLongTracks.value,
+  ).selectedKeys
+  playEvent(selected ? 'toggleOff' : 'toggleOn')
+}
+
+function enableLongTracks() {
+  setAllowLongTracks(true)
+  playEvent('toggleOn')
+}
+
+function appendSelected() {
+  if (!editor || appending.value) return
+
+  const latest = evaluateYoutubePlaylistImport(
+    items.value,
+    editor.playlist.value,
+    selectedKeys.value,
+    allowLongTracks.value,
+  )
+  selectedKeys.value = latest.selectedKeys
+  if (latest.selectedCount === 0) {
+    errorMessage.value = 'Select at least one available track to import.'
+    return
+  }
+
+  appending.value = true
+  errorMessage.value = ''
+  const tracks = latest.items
+    .filter(entry => entry.selected)
+    .map(({ item }) =>
+      pickerVideoToPlaylistTrack({
+        id: item.videoId,
+        title: item.title,
+        channelTitle: item.channelTitle,
+        thumbnailUrl: item.thumbnailUrl,
+        publishedAt: '',
+        duration: item.duration,
+        durationSeconds: item.durationSeconds,
+      }),
+    )
+  const result = editor.appendTracks(tracks)
+  appending.value = false
+
+  if (!result.ok) {
+    errorMessage.value = result.message
+    return
+  }
+
+  playEvent('drop')
+  open.value = false
+}
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape' && open.value) {
+    event.preventDefault()
+    close()
+  }
+}
+
+onMounted(() => document.addEventListener('keydown', onKeydown))
+onUnmounted(() => document.removeEventListener('keydown', onKeydown))
+</script>
+
+<template>
+  <div class="playlist-import-launch">
+    <button
+      type="button"
+      class="maru-button maru-button--sm bg-maru-yellow text-maru-black"
+      :disabled="!canOpen"
+      :title="canOpen ? 'Import tracks from a public YouTube playlist' : 'Select a MYO card first'"
+      @click="show"
+    >
+      <span class="maru-button__label">Import playlist</span>
+    </button>
+  </div>
+
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="playlist-import"
+      @click.self="close"
+    >
+      <section
+        class="playlist-import__dialog border-maru rounded-maru bg-maru-white"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="playlist-import-title"
+      >
+        <header class="playlist-import__header border-maru-bottom">
+          <div>
+            <h2
+              id="playlist-import-title"
+              class="font-maru-bold"
+            >
+              Import a YouTube playlist
+            </h2>
+            <p class="font-maru-mono">
+              Public playlists only. Review every track before adding it.
+            </p>
+          </div>
+          <button
+            type="button"
+            class="playlist-import__close font-maru-mono"
+            aria-label="Close playlist import"
+            :disabled="loading || loadingMore || appending"
+            @click="close"
+          >
+            ×
+          </button>
+        </header>
+
+        <div class="playlist-import__body">
+          <form
+            class="playlist-import__form"
+            @submit.prevent="loadPlaylist"
+          >
+            <label
+              for="playlist-import-url"
+              class="font-maru-mono"
+            >YouTube playlist URL</label>
+            <div class="playlist-import__url-row">
+              <input
+                id="playlist-import-url"
+                ref="inputRef"
+                v-model="url"
+                type="url"
+                inputmode="url"
+                autocomplete="off"
+                placeholder="https://www.youtube.com/playlist?list=…"
+                :disabled="loading || items.length > 0"
+              >
+              <button
+                type="submit"
+                class="maru-button maru-button--sm bg-maru-blue text-maru-white"
+                :disabled="loading || items.length > 0"
+              >
+                <span class="maru-button__label">{{ loading ? 'Loading…' : 'Review' }}</span>
+              </button>
+            </div>
+          </form>
+
+          <p
+            v-if="errorMessage"
+            class="playlist-import__error font-maru-mono"
+            role="alert"
+          >
+            {{ errorMessage }}
+          </p>
+
+          <div
+            v-if="playlist"
+            class="playlist-import__summary"
+          >
+            <div>
+              <h3 class="font-maru-bold">{{ playlist.title }}</h3>
+              <p class="font-maru-mono">
+                {{ playlist.channelTitle }}
+                <template v-if="playlist.itemCount !== undefined">
+                  · {{ playlist.itemCount }} source tracks
+                </template>
+              </p>
+            </div>
+            <p class="font-maru-mono">
+              {{ evaluation.selectedCount }} selected
+              <template v-if="selectedDurationLabel">
+                · {{ selectedDurationLabel }}
+              </template>
+            </p>
+          </div>
+
+          <ul
+            v-if="items.length > 0"
+            class="playlist-import__items"
+          >
+            <li
+              v-for="entry in evaluation.items"
+              :key="entry.item.playlistItemId"
+              class="playlist-import__item"
+              :class="{ 'playlist-import__item--blocked': entry.blockReason }"
+            >
+              <label>
+                <input
+                  type="checkbox"
+                  :checked="entry.selected"
+                  :disabled="Boolean(entry.blockReason) && !entry.selected"
+                  @change="toggleItem(entry.item.playlistItemId, entry.selected, entry.blockReason)"
+                >
+                <img
+                  v-if="entry.item.thumbnailUrl"
+                  :src="entry.item.thumbnailUrl"
+                  alt=""
+                  loading="lazy"
+                >
+                <span class="playlist-import__item-copy">
+                  <strong class="font-maru-medium">{{ entry.item.title }}</strong>
+                  <span class="font-maru-mono">
+                    {{ entry.item.channelTitle }}
+                    <template v-if="entry.item.durationSeconds">
+                      · {{ formatDurationSeconds(entry.item.durationSeconds) }}
+                    </template>
+                  </span>
+                </span>
+                <span
+                  v-if="entry.blockReason"
+                  class="playlist-import__reason font-maru-mono"
+                >
+                  {{ BLOCK_REASON_LABELS[entry.blockReason] }}
+                </span>
+              </label>
+            </li>
+          </ul>
+
+          <div
+            v-if="items.length > 0 && !allowLongTracks && evaluation.items.some(entry => entry.blockReason === 'over-track-duration')"
+            class="playlist-import__long-tracks font-maru-mono"
+          >
+            <span>Some tracks are over Yoto’s 60-minute per-track limit.</span>
+            <button
+              type="button"
+              @click="enableLongTracks"
+            >
+              Allow for this session
+            </button>
+          </div>
+
+          <p
+            v-if="pageErrorMessage"
+            class="playlist-import__error font-maru-mono"
+            role="alert"
+          >
+            {{ pageErrorMessage }}
+          </p>
+
+          <button
+            v-if="nextPageToken"
+            type="button"
+            class="playlist-import__load-more font-maru-mono"
+            :disabled="loadingMore"
+            @click="loadMore"
+          >
+            {{ loadingMore ? 'Loading more…' : 'Load 50 more' }}
+          </button>
+        </div>
+
+        <footer class="playlist-import__footer border-maru-top">
+          <button
+            type="button"
+            class="maru-button maru-button--sm bg-maru-white text-maru-black"
+            :disabled="loading || loadingMore || appending"
+            @click="close"
+          >
+            <span class="maru-button__label">Cancel</span>
+          </button>
+          <button
+            type="button"
+            class="maru-button maru-button--sm bg-maru-green-light text-maru-black"
+            :disabled="evaluation.selectedCount === 0 || loading || loadingMore || appending"
+            @click="appendSelected"
+          >
+            <span class="maru-button__label">
+              Add {{ evaluation.selectedCount || '' }} track{{ evaluation.selectedCount === 1 ? '' : 's' }}
+            </span>
+          </button>
+        </footer>
+      </section>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.playlist-import-launch {
+  display: flex;
+  justify-content: flex-end;
+  padding: .5rem 0 .75rem;
+}
+
+.playlist-import-launch button:disabled {
+  cursor: not-allowed;
+  opacity: .45;
+}
+
+.playlist-import {
+  position: fixed;
+  inset: 0;
+  z-index: 130;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgb(0 0 0 / .55);
+}
+
+.playlist-import__dialog {
+  display: flex;
+  width: min(58rem, 100%);
+  max-height: min(52rem, calc(100vh - 2rem));
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: .5rem .5rem 0 rgb(0 0 0 / .25);
+}
+
+.playlist-import__header,
+.playlist-import__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+}
+
+.playlist-import__header h2,
+.playlist-import__header p,
+.playlist-import__summary h3,
+.playlist-import__summary p {
+  margin: 0;
+}
+
+.playlist-import__header h2 {
+  font-size: 2rem;
+  line-height: .9;
+}
+
+.playlist-import__header p,
+.playlist-import__summary p {
+  margin-top: .35rem;
+  font-size: .85rem;
+}
+
+.playlist-import__close {
+  border: 0;
+  background: transparent;
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.playlist-import__body {
+  min-height: 0;
+  overflow-y: auto;
+  padding: 1rem 1.25rem;
+}
+
+.playlist-import__form label {
+  display: block;
+  margin-bottom: .35rem;
+  font-size: .85rem;
+}
+
+.playlist-import__url-row {
+  display: flex;
+  gap: .65rem;
+}
+
+.playlist-import__url-row input {
+  min-width: 0;
+  flex: 1;
+  border: 2px solid currentcolor;
+  border-radius: var(--radius-maru);
+  padding: .65rem .75rem;
+  background: white;
+  font-family: var(--font-maru-mono);
+}
+
+.playlist-import__error {
+  margin: .75rem 0 0;
+  border-radius: var(--radius-maru);
+  padding: .65rem .75rem;
+  background: var(--color-maru-red-lighter);
+  color: var(--color-maru-red);
+}
+
+.playlist-import__summary {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.playlist-import__summary h3 {
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.playlist-import__items {
+  display: grid;
+  gap: .4rem;
+  margin: 1rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.playlist-import__item {
+  border: 2px solid rgb(0 0 0 / .16);
+  border-radius: var(--radius-maru);
+}
+
+.playlist-import__item--blocked {
+  opacity: .6;
+}
+
+.playlist-import__item label {
+  display: grid;
+  grid-template-columns: auto 5.5rem minmax(0, 1fr) auto;
+  align-items: center;
+  gap: .65rem;
+  padding: .5rem;
+  cursor: pointer;
+}
+
+.playlist-import__item input {
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+.playlist-import__item img {
+  width: 5.5rem;
+  aspect-ratio: 16 / 9;
+  border-radius: calc(var(--radius-maru) - 3px);
+  object-fit: cover;
+}
+
+.playlist-import__item-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.playlist-import__item-copy strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.playlist-import__item-copy span,
+.playlist-import__reason {
+  font-size: .78rem;
+}
+
+.playlist-import__reason {
+  border-radius: 999px;
+  padding: .25rem .45rem;
+  background: rgb(0 0 0 / .08);
+  white-space: nowrap;
+}
+
+.playlist-import__long-tracks {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .75rem;
+  margin-top: .75rem;
+  font-size: .8rem;
+}
+
+.playlist-import__long-tracks button,
+.playlist-import__load-more {
+  border: 0;
+  padding: .35rem 0;
+  background: transparent;
+  text-decoration: underline;
+}
+
+.playlist-import__load-more {
+  display: block;
+  margin: .75rem auto 0;
+}
+
+.playlist-import__footer {
+  justify-content: flex-end;
+}
+
+@media (max-width: 640px) {
+  .playlist-import__url-row,
+  .playlist-import__summary,
+  .playlist-import__long-tracks {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .playlist-import__item label {
+    grid-template-columns: auto 4.5rem minmax(0, 1fr);
+  }
+
+  .playlist-import__item img {
+    width: 4.5rem;
+  }
+
+  .playlist-import__reason {
+    grid-column: 2 / -1;
+    justify-self: start;
+  }
+}
+</style>

--- a/app/components/youtube-picker/index.vue
+++ b/app/components/youtube-picker/index.vue
@@ -8,6 +8,7 @@
 <script setup lang="ts">
 import { useYoutubePicker } from './useYoutubePicker'
 import YoutubePickerPreview from './YoutubePickerPreview.vue'
+import YoutubePlaylistImport from './YoutubePlaylistImport.vue'
 import YoutubePickerResultsPane from './YoutubePickerResultsPane.vue'
 import YoutubePickerSearch from './YoutubePickerSearch.vue'
 import {
@@ -153,6 +154,7 @@ onUnmounted(() => {
         @submit="onSearchSubmit"
         @clear="onSearchClear"
       />
+      <YoutubePlaylistImport />
     </div>
 
     <div :class="embedded ? 'flex flex-1 min-h-0 flex-col overflow-hidden' : ''">

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "start": "node .output/server/index.mjs",
-    "test": "node --experimental-strip-types --test shared/**/*.test.ts",
+    "test": "node --experimental-strip-types --test shared/**/*.test.ts server/**/*.test.ts",
     "postinstall": "nuxt prepare",
     "release": "release-it"
   },

--- a/server/api/youtube/playlist.get.ts
+++ b/server/api/youtube/playlist.get.ts
@@ -1,0 +1,188 @@
+import {
+  isYoutubePlaylistId,
+  type YoutubePlaylistImportResponse,
+} from '#shared/myo-editor/youtubePlaylistImport'
+import { parseYoutubeDurationIso } from '#shared/myo-editor/youtubeDuration'
+import {
+  decodeHtmlEntities,
+  fetchYoutubeApiCached,
+  getYoutubeApiKey,
+  pickThumbnail,
+} from '../../utils/youtube'
+import { fetchYoutubePlaylistPageSources } from '../../utils/youtube-playlist'
+
+interface YoutubePlaylistListItem {
+  id: string
+  snippet?: {
+    title?: string
+    channelTitle?: string
+  }
+  contentDetails?: {
+    itemCount?: number
+  }
+  status?: {
+    privacyStatus?: string
+  }
+}
+
+interface YoutubePlaylistListResponse {
+  items?: YoutubePlaylistListItem[]
+}
+
+interface YoutubePlaylistItem {
+  id: string
+  snippet?: {
+    title?: string
+    channelTitle?: string
+    position?: number
+    thumbnails?: Record<string, { url: string } | undefined>
+    resourceId?: {
+      videoId?: string
+    }
+  }
+  contentDetails?: {
+    videoId?: string
+  }
+}
+
+interface YoutubePlaylistItemsResponse {
+  items?: YoutubePlaylistItem[]
+  nextPageToken?: string
+}
+
+interface YoutubeVideoItem {
+  id: string
+  snippet?: {
+    title?: string
+    channelTitle?: string
+    thumbnails?: Record<string, { url: string } | undefined>
+  }
+  contentDetails?: {
+    duration?: string
+  }
+  status?: {
+    uploadStatus?: string
+    privacyStatus?: string
+  }
+}
+
+interface YoutubeVideosResponse {
+  items?: YoutubeVideoItem[]
+}
+
+export default defineEventHandler(async (event): Promise<YoutubePlaylistImportResponse> => {
+  const query = getQuery(event)
+  const playlistId = String(query.playlistId ?? '').trim()
+  const pageToken = query.pageToken ? String(query.pageToken) : undefined
+
+  if (!isYoutubePlaylistId(playlistId)) {
+    throw createError({
+      statusCode: 400,
+      message: 'A valid YouTube playlist ID is required',
+    })
+  }
+
+  const apiKey = getYoutubeApiKey(event)
+  const [playlistData, itemsData] = await fetchYoutubePlaylistPageSources<
+    YoutubePlaylistListResponse,
+    YoutubePlaylistItemsResponse
+  >(fetchYoutubeApiCached, {
+    playlistId,
+    pageToken,
+    apiKey,
+  })
+  const playlistItem = playlistData?.items?.[0]
+
+  if (!playlistItem) {
+    throw createError({
+      statusCode: 404,
+      message: 'Public YouTube playlist not found',
+    })
+  }
+  if (playlistItem?.status?.privacyStatus !== 'public') {
+    throw createError({
+      statusCode: 400,
+      message: 'Only public YouTube playlists can be imported',
+    })
+  }
+
+  const sourceItems = itemsData.items ?? []
+  const videoIds = [
+    ...new Set(
+      sourceItems
+        .map(item => item.contentDetails?.videoId ?? item.snippet?.resourceId?.videoId)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  ]
+
+  let videosData: YoutubeVideosResponse = {}
+  if (videoIds.length > 0) {
+    const videosParams = new URLSearchParams({
+      part: 'snippet,contentDetails,status',
+      id: videoIds.join(','),
+      key: apiKey,
+    })
+    videosData = await fetchYoutubeApiCached<YoutubeVideosResponse>(
+      `playlist-videos:${[...videoIds].sort().join(',')}`,
+      `https://www.googleapis.com/youtube/v3/videos?${videosParams}`,
+    )
+  }
+
+  const videosById = new Map(
+    (videosData.items ?? []).map(video => [video.id, video]),
+  )
+
+  return {
+    playlist: playlistItem
+      ? {
+          id: playlistItem.id,
+          title: decodeHtmlEntities(playlistItem.snippet?.title ?? 'YouTube playlist'),
+          channelTitle: decodeHtmlEntities(playlistItem.snippet?.channelTitle ?? ''),
+          itemCount: playlistItem.contentDetails?.itemCount,
+        }
+      : undefined,
+    items: sourceItems.map((sourceItem, index) => {
+      const videoId
+        = sourceItem.contentDetails?.videoId
+          ?? sourceItem.snippet?.resourceId?.videoId
+          ?? ''
+      const video = videosById.get(videoId)
+      const duration = video?.contentDetails?.duration
+      const durationSeconds = duration
+        ? parseYoutubeDurationIso(duration) ?? undefined
+        : undefined
+      const uploadStatus = video?.status?.uploadStatus?.toLowerCase()
+      const privacyStatus = video?.status?.privacyStatus?.toLowerCase()
+      const available = Boolean(
+        video
+        && privacyStatus !== 'private'
+        && (!uploadStatus || uploadStatus === 'processed' || uploadStatus === 'uploaded'),
+      )
+
+      return {
+        playlistItemId: sourceItem.id || `${playlistId}:${pageToken ?? 'first'}:${index}`,
+        videoId,
+        position: sourceItem.snippet?.position ?? index,
+        title: decodeHtmlEntities(
+          video?.snippet?.title
+          ?? sourceItem.snippet?.title
+          ?? 'Unavailable video',
+        ),
+        channelTitle: decodeHtmlEntities(
+          video?.snippet?.channelTitle
+          ?? sourceItem.snippet?.channelTitle
+          ?? '',
+        ),
+        thumbnailUrl: pickThumbnail(
+          video?.snippet?.thumbnails
+          ?? sourceItem.snippet?.thumbnails
+          ?? {},
+        ),
+        duration,
+        durationSeconds,
+        available,
+      }
+    }),
+    nextPageToken: itemsData.nextPageToken,
+  }
+})

--- a/server/utils/youtube-playlist.test.ts
+++ b/server/utils/youtube-playlist.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { fetchYoutubePlaylistPageSources } from './youtube-playlist.ts'
+
+describe('fetchYoutubePlaylistPageSources', () => {
+  it('retains public-playlist metadata validation for paginated requests', async () => {
+    const calls: Array<{ cacheKey: string, url: string }> = []
+    const playlistResponse = { items: [{ id: 'PL1234567890' }] }
+    const itemsResponse = { items: [], nextPageToken: 'next-token' }
+
+    const fetchCached = async <T>(cacheKey: string, url: string): Promise<T> => {
+      calls.push({ cacheKey, url })
+      return (cacheKey.startsWith('playlist-items:')
+        ? itemsResponse
+        : playlistResponse) as T
+    }
+
+    const [playlist, items] = await fetchYoutubePlaylistPageSources<
+      typeof playlistResponse,
+      typeof itemsResponse
+    >(fetchCached, {
+      playlistId: 'PL1234567890',
+      pageToken: 'page-two-token',
+      apiKey: 'test-key',
+    })
+
+    assert.equal(playlist, playlistResponse)
+    assert.equal(items, itemsResponse)
+    assert.equal(calls.length, 2)
+    assert.equal(calls[0]?.cacheKey, 'playlist:PL1234567890')
+    assert.match(calls[0]?.url ?? '', /\/youtube\/v3\/playlists\?/)
+    assert.equal(calls[1]?.cacheKey, 'playlist-items:PL1234567890:page-two-token')
+    assert.match(calls[1]?.url ?? '', /pageToken=page-two-token/)
+  })
+})

--- a/server/utils/youtube-playlist.ts
+++ b/server/utils/youtube-playlist.ts
@@ -1,0 +1,41 @@
+export interface YoutubePlaylistPageSourceOptions {
+  playlistId: string
+  pageToken?: string
+  apiKey: string
+}
+
+type YoutubeApiFetcher = <T>(cacheKey: string, url: string) => Promise<T>
+
+/**
+ * Fetch playlist metadata on every page so public-only validation cannot be
+ * bypassed or accidentally skipped. The shared API cache avoids repeat quota
+ * cost while the user pages through a playlist.
+ */
+export async function fetchYoutubePlaylistPageSources<TPlaylist, TItems>(
+  fetchCached: YoutubeApiFetcher,
+  options: YoutubePlaylistPageSourceOptions,
+): Promise<[TPlaylist, TItems]> {
+  const playlistParams = new URLSearchParams({
+    part: 'snippet,contentDetails,status',
+    id: options.playlistId,
+    key: options.apiKey,
+  })
+  const itemsParams = new URLSearchParams({
+    part: 'snippet,contentDetails',
+    playlistId: options.playlistId,
+    maxResults: '50',
+    key: options.apiKey,
+  })
+  if (options.pageToken) itemsParams.set('pageToken', options.pageToken)
+
+  return await Promise.all([
+    fetchCached<TPlaylist>(
+      `playlist:${options.playlistId}`,
+      `https://www.googleapis.com/youtube/v3/playlists?${playlistParams}`,
+    ),
+    fetchCached<TItems>(
+      `playlist-items:${options.playlistId}:${options.pageToken ?? ''}`,
+      `https://www.googleapis.com/youtube/v3/playlistItems?${itemsParams}`,
+    ),
+  ])
+}

--- a/shared/myo-editor/youtubePlaylistImport.test.ts
+++ b/shared/myo-editor/youtubePlaylistImport.test.ts
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import type { PlaylistTrack } from './types.ts'
+import {
+  evaluateYoutubePlaylistImport,
+  parseYoutubePlaylistUrl,
+  preselectYoutubePlaylistImport,
+  type YoutubePlaylistImportItem,
+} from './youtubePlaylistImport.ts'
+import {
+  YOTO_MYO_MAX_CARD_SECONDS,
+  YOTO_MYO_MAX_TRACK_SECONDS,
+  YOTO_MYO_MAX_TRACKS,
+} from './yotoMyoLimits.ts'
+
+function item(
+  id: string,
+  partial: Partial<YoutubePlaylistImportItem> = {},
+): YoutubePlaylistImportItem {
+  return {
+    playlistItemId: `item-${id}`,
+    videoId: id,
+    position: 0,
+    title: id,
+    channelTitle: 'Channel',
+    thumbnailUrl: '',
+    durationSeconds: 60,
+    available: true,
+    ...partial,
+  }
+}
+
+function track(
+  id: string,
+  partial: Partial<PlaylistTrack> = {},
+): PlaylistTrack {
+  return {
+    id,
+    title: id,
+    subtitle: '',
+    thumbnailUrl: '',
+    source: 'app-youtube',
+    youtubeId: id,
+    duration: 60,
+    ...partial,
+  }
+}
+
+describe('parseYoutubePlaylistUrl', () => {
+  it('accepts supported HTTPS YouTube hosts', () => {
+    assert.equal(
+      parseYoutubePlaylistUrl('https://www.youtube.com/playlist?list=PL1234567890'),
+      'PL1234567890',
+    )
+    assert.equal(
+      parseYoutubePlaylistUrl('https://music.youtube.com/watch?v=abc&list=PLabcdefghij'),
+      'PLabcdefghij',
+    )
+    assert.equal(
+      parseYoutubePlaylistUrl('https://youtu.be/abc?list=PLabcdefghij'),
+      'PLabcdefghij',
+    )
+  })
+
+  it('rejects ambiguous, spoofed, and non-HTTPS URLs', () => {
+    assert.equal(parseYoutubePlaylistUrl('PL1234567890'), null)
+    assert.equal(parseYoutubePlaylistUrl('http://youtube.com/playlist?list=PL1234567890'), null)
+    assert.equal(parseYoutubePlaylistUrl('https://youtube.com.example/playlist?list=PL1234567890'), null)
+    assert.equal(
+      parseYoutubePlaylistUrl('https://youtube.com/playlist?list=PL1234567890&list=PLabcdefghij'),
+      null,
+    )
+  })
+})
+
+describe('YouTube playlist import selection', () => {
+  it('preselects valid unique items in source order', () => {
+    const plan = preselectYoutubePlaylistImport(
+      [
+        item('one'),
+        item('two'),
+        item('one', { playlistItemId: 'item-one-again' }),
+      ],
+      [],
+      false,
+    )
+
+    assert.deepEqual([...plan.selectedKeys], ['item-one', 'item-two'])
+    assert.equal(plan.items[2]?.blockReason, 'duplicate-source')
+  })
+
+  it('blocks existing, unavailable, missing-duration, and long tracks', () => {
+    const plan = preselectYoutubePlaylistImport(
+      [
+        item('existing'),
+        item('gone', { available: false }),
+        item('unknown', { durationSeconds: undefined }),
+        item('long', { durationSeconds: YOTO_MYO_MAX_TRACK_SECONDS + 1 }),
+      ],
+      [track('existing')],
+      false,
+    )
+
+    assert.deepEqual(
+      plan.items.map(entry => entry.blockReason),
+      ['duplicate-existing', 'unavailable', 'missing-duration', 'over-track-duration'],
+    )
+    assert.equal(plan.selectedCount, 0)
+  })
+
+  it('allows long tracks when enabled', () => {
+    const long = item('long', { durationSeconds: YOTO_MYO_MAX_TRACK_SECONDS + 1 })
+    const plan = preselectYoutubePlaylistImport([long], [], true)
+    assert.deepEqual([...plan.selectedKeys], [long.playlistItemId])
+  })
+
+  it('allows exact track and duration capacity', () => {
+    const existing = Array.from({ length: YOTO_MYO_MAX_TRACKS - 1 }, (_, index) =>
+      track(`existing-${index}`, { duration: 1 }),
+    )
+    const remainingDuration
+      = YOTO_MYO_MAX_CARD_SECONDS - (YOTO_MYO_MAX_TRACKS - 1)
+    const candidate = item('last', { durationSeconds: remainingDuration })
+    const plan = preselectYoutubePlaylistImport([candidate], existing, true)
+
+    assert.equal(plan.selectedCount, 1)
+  })
+
+  it('keeps earlier requested selections when capacity is exceeded', () => {
+    const existing = Array.from({ length: YOTO_MYO_MAX_TRACKS - 1 }, (_, index) =>
+      track(`existing-${index}`),
+    )
+    const first = item('first')
+    const second = item('second')
+    const requested = new Set([first.playlistItemId, second.playlistItemId])
+    const plan = evaluateYoutubePlaylistImport([first, second], existing, requested, false)
+
+    assert.deepEqual([...plan.selectedKeys], [first.playlistItemId])
+    assert.equal(plan.items[1]?.blockReason, 'track-capacity')
+  })
+})

--- a/shared/myo-editor/youtubePlaylistImport.ts
+++ b/shared/myo-editor/youtubePlaylistImport.ts
@@ -1,0 +1,214 @@
+import type { PlaylistTrack } from './types.ts'
+import {
+  YOTO_MYO_MAX_CARD_SECONDS,
+  YOTO_MYO_MAX_TRACK_SECONDS,
+  YOTO_MYO_MAX_TRACKS,
+} from './yotoMyoLimits.ts'
+
+const YOUTUBE_PLAYLIST_HOSTS = new Set([
+  'youtube.com',
+  'www.youtube.com',
+  'm.youtube.com',
+  'music.youtube.com',
+  'youtu.be',
+])
+
+const YOUTUBE_PLAYLIST_ID = /^[A-Za-z0-9_-]{10,100}$/
+
+export interface YoutubePlaylistSummary {
+  id: string
+  title: string
+  channelTitle: string
+  itemCount?: number
+}
+
+export interface YoutubePlaylistImportItem {
+  playlistItemId: string
+  videoId: string
+  position: number
+  title: string
+  channelTitle: string
+  thumbnailUrl: string
+  duration?: string
+  durationSeconds?: number
+  available: boolean
+}
+
+export interface YoutubePlaylistImportResponse {
+  playlist?: YoutubePlaylistSummary
+  items: YoutubePlaylistImportItem[]
+  nextPageToken?: string
+}
+
+export type YoutubePlaylistImportBlockReason =
+  | 'unavailable'
+  | 'missing-duration'
+  | 'over-track-duration'
+  | 'duplicate-existing'
+  | 'duplicate-source'
+  | 'track-capacity'
+  | 'duration-capacity'
+
+export interface YoutubePlaylistImportEvaluation {
+  items: Array<{
+    item: YoutubePlaylistImportItem
+    selected: boolean
+    blockReason?: YoutubePlaylistImportBlockReason
+  }>
+  selectedKeys: Set<string>
+  selectedCount: number
+  selectedDurationSeconds: number
+}
+
+export function isYoutubePlaylistId(value: string): boolean {
+  return YOUTUBE_PLAYLIST_ID.test(value)
+}
+
+export function parseYoutubePlaylistUrl(value: string): string | null {
+  let url: URL
+  try {
+    url = new URL(value.trim())
+  }
+  catch {
+    return null
+  }
+
+  if (url.protocol !== 'https:' || !YOUTUBE_PLAYLIST_HOSTS.has(url.hostname.toLowerCase())) {
+    return null
+  }
+
+  const values = url.searchParams.getAll('list')
+  if (values.length !== 1) return null
+
+  const playlistId = values[0]?.trim() ?? ''
+  return isYoutubePlaylistId(playlistId) ? playlistId : null
+}
+
+function trackDurationSeconds(track: PlaylistTrack): number | undefined {
+  if (typeof track.duration === 'number' && Number.isFinite(track.duration) && track.duration > 0) {
+    return track.duration
+  }
+  const duration = track.yotoReuse?.duration
+  if (typeof duration === 'number' && Number.isFinite(duration) && duration > 0) {
+    return duration
+  }
+  return undefined
+}
+
+function baseBlockReason(
+  item: YoutubePlaylistImportItem,
+  existingYoutubeIds: Set<string>,
+  isLaterSourceDuplicate: boolean,
+  allowLongTracks: boolean,
+): YoutubePlaylistImportBlockReason | undefined {
+  if (!item.available) return 'unavailable'
+  if (
+    typeof item.durationSeconds !== 'number'
+    || !Number.isFinite(item.durationSeconds)
+    || item.durationSeconds <= 0
+  ) {
+    return 'missing-duration'
+  }
+  if (!allowLongTracks && item.durationSeconds > YOTO_MYO_MAX_TRACK_SECONDS) {
+    return 'over-track-duration'
+  }
+  if (existingYoutubeIds.has(item.videoId)) return 'duplicate-existing'
+  if (isLaterSourceDuplicate) return 'duplicate-source'
+  return undefined
+}
+
+/**
+ * Evaluates a requested import selection in source order. If the request is
+ * over capacity, earlier playlist entries win and later entries are disabled.
+ */
+export function evaluateYoutubePlaylistImport(
+  items: YoutubePlaylistImportItem[],
+  existingPlaylist: PlaylistTrack[],
+  requestedSelectedKeys: ReadonlySet<string>,
+  allowLongTracks: boolean,
+): YoutubePlaylistImportEvaluation {
+  const existingYoutubeIds = new Set(
+    existingPlaylist
+      .map(track => track.youtubeId)
+      .filter((id): id is string => Boolean(id)),
+  )
+  const firstSourceItemByVideoId = new Map<string, string>()
+  for (const item of items) {
+    if (!firstSourceItemByVideoId.has(item.videoId)) {
+      firstSourceItemByVideoId.set(item.videoId, item.playlistItemId)
+    }
+  }
+
+  let trackCount = existingPlaylist.length
+  let durationSeconds = existingPlaylist.reduce(
+    (sum, track) => sum + (trackDurationSeconds(track) ?? 0),
+    0,
+  )
+  const selectedKeys = new Set<string>()
+  const result: YoutubePlaylistImportEvaluation['items'] = []
+
+  for (const item of items) {
+    const isLaterDuplicate
+      = firstSourceItemByVideoId.get(item.videoId) !== item.playlistItemId
+    const baseReason = baseBlockReason(
+      item,
+      existingYoutubeIds,
+      isLaterDuplicate,
+      allowLongTracks,
+    )
+
+    if (baseReason) {
+      result.push({ item, selected: false, blockReason: baseReason })
+      continue
+    }
+
+    const duration = item.durationSeconds!
+    const overTrackCapacity = trackCount + 1 > YOTO_MYO_MAX_TRACKS
+    const overDurationCapacity = durationSeconds + duration > YOTO_MYO_MAX_CARD_SECONDS
+    const capacityReason: YoutubePlaylistImportBlockReason | undefined
+      = overTrackCapacity
+        ? 'track-capacity'
+        : overDurationCapacity
+          ? 'duration-capacity'
+          : undefined
+
+    if (requestedSelectedKeys.has(item.playlistItemId) && !capacityReason) {
+      selectedKeys.add(item.playlistItemId)
+      trackCount += 1
+      durationSeconds += duration
+      result.push({ item, selected: true })
+      continue
+    }
+
+    result.push({
+      item,
+      selected: false,
+      blockReason: capacityReason,
+    })
+  }
+
+  const existingDurationSeconds = existingPlaylist.reduce(
+    (sum, track) => sum + (trackDurationSeconds(track) ?? 0),
+    0,
+  )
+
+  return {
+    items: result,
+    selectedKeys,
+    selectedCount: selectedKeys.size,
+    selectedDurationSeconds: durationSeconds - existingDurationSeconds,
+  }
+}
+
+export function preselectYoutubePlaylistImport(
+  items: YoutubePlaylistImportItem[],
+  existingPlaylist: PlaylistTrack[],
+  allowLongTracks: boolean,
+): YoutubePlaylistImportEvaluation {
+  return evaluateYoutubePlaylistImport(
+    items,
+    existingPlaylist,
+    new Set(items.map(item => item.playlistItemId)),
+    allowLongTracks,
+  )
+}


### PR DESCRIPTION
## Summary

- Add a review-before-append flow for public YouTube playlists.
- Load playlist entries in source order with 50-item pagination.
- Filter unavailable, duplicate, over-hour, and over-capacity tracks.
- Append the accepted selection to the active MYO playlist atomically.
- Document first-class chapter and track editing as a future direction.

## Why

Building a MYO playlist one search result at a time is repetitive, especially when the desired collection already exists as a YouTube playlist.

This adds a faster workflow while keeping the user in control: paste a public playlist URL, review the available tracks, adjust the selection, and add the result to the current card.

## Implementation notes

- Accepts full HTTPS URLs from supported YouTube hosts.
- Uses the YouTube Data API through the existing server-side API-key boundary.
- Enriches playlist items with availability and duration metadata.
- Preserves source ordering across pages.
- Detects duplicates using the YouTube video ID.
- Revalidates the selection against MYO track-count and duration limits.
- Leaves the existing Yoto save, upload, and transcode pipeline unchanged.
- Reuses cached playlist metadata when validating paginated requests.

## Validation

- `npm test` — 72 tests passed.
- `npm run build` — production build passed.
- Manually imported and saved a 33-track, 121-minute YouTube playlist to Yoto.
- Added regression coverage ensuring paginated requests retain public-playlist validation.

## Current scope

- Public playlists only.
- Private and unlisted playlists are not supported.
- Tracks with unavailable or missing metadata remain visible but cannot be selected.
- Pagination beyond 50 entries is covered automatically but has not yet received a manual browser test.
