### PR TITLE
Add YouTube playlist import and standalone creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ How we cut releases: [docs/RELEASE.md](docs/RELEASE.md).
 ## [Unreleased]
 
 ### Added
+- Standalone Yoto playlist creation from local drafts with reviewed YouTube tracks and explicit Create confirmation.
 - Review-and-append import for public YouTube playlists, including pagination, duplicate detection, availability checks, and MYO capacity filtering.
 - yt-dlp download outcome logs (`ok` / `fail` / `escalate` / `coalesce`) so Railway logs show whether cookies recovered after bot checks.
 - In-process singleflight for concurrent downloads of the same YouTube id (preview stampede protection).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ How we cut releases: [docs/RELEASE.md](docs/RELEASE.md).
 ## [Unreleased]
 
 ### Added
+- Review-and-append import for public YouTube playlists, including pagination, duplicate detection, availability checks, and MYO capacity filtering.
 - yt-dlp download outcome logs (`ok` / `fail` / `escalate` / `coalesce`) so Railway logs show whether cookies recovered after bot checks.
 - In-process singleflight for concurrent downloads of the same YouTube id (preview stampede protection).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,6 +44,12 @@ Phone layout for the three-panel editor. On small screens YouTube result titles 
 
 Optional per-result toggle to expand YouTube chapters into separate playlist tracks. Must compose cleanly with auto ~1-hour long-track splitting.
 
+### First-class chapter and track editing
+
+Preserve Yoto’s nested playlist model in the editor: add, rename, reorder, and delete chapters; allow multiple tracks per chapter; and expose track end behavior where useful.
+
+Use [`@lizozom/yoto`](https://github.com/lizozom/yoto-cli) as an API/schema reference or evaluate its MIT-licensed library directly. Keep Louis’s browser PKCE session authoritative rather than shelling out to a host-installed CLI, so the feature also works in Docker.
+
 ### Desktop app wrapper (Electron or Tauri)
 
 Package Louis as a cross-OS executable so less technical users can run it without Docker/GitHub CLI — consumer-friendly install alongside the one-click hosting work.

--- a/app/components/myo-editor/useMyoEditor.ts
+++ b/app/components/myo-editor/useMyoEditor.ts
@@ -1,6 +1,18 @@
 import type { InjectionKey } from 'vue'
 import type { PlaylistTrack } from '~/components/playlist/types'
 import { playlistRowId } from '#shared/myo-editor/playlistRowId'
+import {
+  classifyCreateStartFailure,
+  type ClientSaveIdentity,
+  type ClientSaveTarget,
+  getStandalonePlaylistValidationError,
+  isPlaylistEditorActive,
+  NEW_PLAYLIST_SAVE_KEY,
+  notifyConfirmedPlaylistCreated,
+  resolveClientSaveTarget,
+  resolveSavedCardId,
+  shouldWarnBeforeUnload,
+} from '#shared/myo-editor/standalonePlaylist'
 import type { SaveJobPhase } from '#shared/myo-editor/types'
 import type { YotoMyoCard } from '~/components/yoto-myo/types'
 import { cardToPlaylist } from './cardToPlaylist'
@@ -30,7 +42,9 @@ export interface CardSaveSnapshot {
 }
 
 export interface CardSaveState {
-  cardId: string
+  saveKey: string
+  /** Populated only when Yoto has supplied or Louis already has a real card ID. */
+  cardId?: string
   jobId: string
   status: SaveJobPhase
   progress: number
@@ -43,6 +57,7 @@ export interface CardSaveState {
 
 export interface MyoEditorContext {
   selectedCardId: Ref<string | null>
+  isNewPlaylist: Ref<boolean>
   cardTitle: Ref<string>
   playlist: Ref<PlaylistTrack[]>
   isEditing: ComputedRef<boolean>
@@ -52,12 +67,15 @@ export interface MyoEditorContext {
   isPlaylistLocked: ComputedRef<boolean>
   saveProgress: ComputedRef<SaveProgress | null>
   errorMessage: Ref<string>
+  createOutcomeUncertain: Ref<boolean>
   isDirty: ComputedRef<boolean>
   isCardSaving: (cardId: string) => boolean
+  startNewPlaylist: () => boolean
   selectCard: (card: YotoMyoCard) => Promise<void>
   clearSelection: (force?: boolean) => boolean
   resetChanges: () => void
   appendTracks: (tracks: PlaylistTrack[]) => { ok: true, added: number } | { ok: false, message: string }
+  createPlaylist: (options?: { acknowledgeCapacityRisk?: boolean }) => Promise<void>
   updateCard: (options?: { acknowledgeCapacityRisk?: boolean }) => Promise<void>
 }
 
@@ -94,16 +112,17 @@ function jobToSaveProgress(state: CardSaveState): SaveProgress {
 }
 
 function saveStateFromJob(
-  cardId: string,
+  saveKey: string,
   job: SaveJobState,
   snapshot: CardSaveSnapshot,
   startedAt: number,
 ): CardSaveState {
   return {
-    cardId,
+    saveKey,
+    cardId: job.cardId,
     jobId: job.id,
     status: job.status,
-    progress: monotonicOverallProgress(cardId, job.progress),
+    progress: monotonicOverallProgress(saveKey, job.progress),
     operationProgress: job.operationProgress ?? 0,
     error: job.error,
     tracks: job.tracks,
@@ -117,22 +136,27 @@ const POLL_TIMEOUT_MS = 30 * 60 * 1000
 const MIN_COMPLETE_DISPLAY_MS = 450
 
 const pollingJobIds = new Set<string>()
-const maxOverallProgressByCard = new Map<string, number>()
+const maxOverallProgressBySaveKey = new Map<string, number>()
 
-function monotonicOverallProgress(cardId: string, next: number): number {
-  const prev = maxOverallProgressByCard.get(cardId) ?? 0
+export interface UseMyoEditorOptions {
+  onPlaylistCreated?: (cardId: string) => void
+}
+
+function monotonicOverallProgress(saveKey: string, next: number): number {
+  const prev = maxOverallProgressBySaveKey.get(saveKey) ?? 0
   const value = Math.max(prev, Math.min(100, Math.round(next)))
-  maxOverallProgressByCard.set(cardId, value)
+  maxOverallProgressBySaveKey.set(saveKey, value)
   return value
 }
 
-function clearProgressTracking(cardId: string) {
-  maxOverallProgressByCard.delete(cardId)
+function clearProgressTracking(saveKey: string) {
+  maxOverallProgressBySaveKey.delete(saveKey)
 }
 
-export function useMyoEditor() {
+export function useMyoEditor(options: UseMyoEditorOptions = {}) {
   const { playEvent } = useUiSound()
   const selectedCardId = ref<string | null>(null)
+  const isNewPlaylist = ref(false)
   const cardTitle = ref('')
   const playlist = ref<PlaylistTrack[]>([])
   const baselinePlaylist = ref<PlaylistTrack[]>([])
@@ -140,43 +164,56 @@ export function useMyoEditor() {
   const isPodcast = ref(false)
   const loading = ref(false)
   const errorMessage = ref('')
+  const createOutcomeUncertain = ref(false)
   const activeSaves = ref(new Map<string, CardSaveState>())
 
   function touchActiveSaves() {
     activeSaves.value = new Map(activeSaves.value)
   }
 
-  function getSaveState(cardId: string): CardSaveState | undefined {
-    return activeSaves.value.get(cardId)
+  function getSaveState(saveKey: string): CardSaveState | undefined {
+    return activeSaves.value.get(saveKey)
   }
 
-  function setSaveState(cardId: string, state: CardSaveState) {
-    activeSaves.value.set(cardId, state)
+  function setSaveState(saveKey: string, state: CardSaveState) {
+    activeSaves.value.set(saveKey, state)
     touchActiveSaves()
   }
 
-  function deleteSaveState(cardId: string) {
-    if (!activeSaves.value.has(cardId)) return
-    activeSaves.value.delete(cardId)
-    clearProgressTracking(cardId)
+  function deleteSaveState(saveKey: string) {
+    if (!activeSaves.value.has(saveKey)) return
+    activeSaves.value.delete(saveKey)
+    clearProgressTracking(saveKey)
     touchActiveSaves()
   }
 
-  function isCardSaving(cardId: string): boolean {
-    const state = getSaveState(cardId)
+  function isSaveActive(saveKey: string): boolean {
+    const state = getSaveState(saveKey)
     return Boolean(state && !isTerminalStatus(state.status))
   }
 
-  const isEditing = computed(() => Boolean(selectedCardId.value))
+  function isCardSaving(cardId: string): boolean {
+    return isSaveActive(cardId)
+  }
+
+  const isEditing = computed(() =>
+    isPlaylistEditorActive(selectedCardId.value, isNewPlaylist.value),
+  )
 
   const isDirty = computed(
-    () => playlistSnapshot(playlist.value) !== playlistSnapshot(baselinePlaylist.value),
+    () => isNewPlaylist.value
+      ? Boolean(cardTitle.value.trim() || playlist.value.length > 0)
+      : playlistSnapshot(playlist.value) !== playlistSnapshot(baselinePlaylist.value),
+  )
+
+  const selectedSaveKey = computed(() =>
+    isNewPlaylist.value ? NEW_PLAYLIST_SAVE_KEY : selectedCardId.value,
   )
 
   const selectedSaveState = computed(() => {
-    const cardId = selectedCardId.value
-    if (!cardId) return null
-    return getSaveState(cardId) ?? null
+    const saveKey = selectedSaveKey.value
+    if (!saveKey) return null
+    return getSaveState(saveKey) ?? null
   })
 
   const isPlaylistLocked = computed(() => {
@@ -256,28 +293,35 @@ export function useMyoEditor() {
     removePersistedSave(cardId)
   }
 
-  function handleSaveFailed(cardId: string, message: string) {
+  function handleSaveFailed(
+    saveKey: string,
+    message: string,
+    outcomeUncertain = false,
+  ) {
     playEvent('saveError')
     const displayMessage = message.length > 240 ? `${message.slice(0, 237)}…` : message
-    deleteSaveState(cardId)
-    removePersistedSave(cardId)
+    deleteSaveState(saveKey)
+    removePersistedSave(saveKey)
 
-    if (selectedCardId.value === cardId) {
+    if (selectedSaveKey.value === saveKey) {
+      if (saveKey === NEW_PLAYLIST_SAVE_KEY && outcomeUncertain) {
+        createOutcomeUncertain.value = true
+      }
       errorMessage.value = displayMessage
     }
   }
 
-  function updateSaveStateFromJob(cardId: string, job: SaveJobState) {
-    const existing = getSaveState(cardId)
+  function updateSaveStateFromJob(saveKey: string, job: SaveJobState) {
+    const existing = getSaveState(saveKey)
     if (!existing) return
 
     const isComplete = job.status === 'complete'
 
-    setSaveState(cardId, {
+    setSaveState(saveKey, {
       ...existing,
       status: isComplete ? 'posting' : job.status,
       progress: monotonicOverallProgress(
-        cardId,
+        saveKey,
         isComplete ? 100 : job.progress,
       ),
       operationProgress: isComplete ? 100 : (job.operationProgress ?? existing.operationProgress),
@@ -286,45 +330,102 @@ export function useMyoEditor() {
     })
   }
 
-  async function pollSaveJob(cardId: string, jobId: string, titleFallback: string) {
+  function promoteCreatedPlaylist(saveKey: string, cardId: string) {
+    const state = getSaveState(saveKey)
+    if (state) {
+      activeSaves.value.delete(saveKey)
+      clearProgressTracking(saveKey)
+      maxOverallProgressBySaveKey.set(cardId, state.progress)
+      activeSaves.value.set(cardId, { ...state, saveKey: cardId, cardId })
+      baselinePlaylist.value = clonePlaylist(state.snapshot.playlist)
+      cardTitle.value = state.snapshot.cardTitle
+      touchActiveSaves()
+    }
+
+    selectedCardId.value = cardId
+    isNewPlaylist.value = false
+    createOutcomeUncertain.value = false
+  }
+
+  async function pollSaveJob(
+    saveKey: string,
+    jobId: string,
+    titleFallback: string,
+    target: ClientSaveIdentity,
+  ) {
     if (pollingJobIds.has(jobId)) return
     pollingJobIds.add(jobId)
 
-    const existing = getSaveState(cardId)
+    const existing = getSaveState(saveKey)
     const startedAt = existing?.startedAt ?? Date.now()
 
     try {
       let job = await $fetch<SaveJobState>(`/api/yoto/jobs/${jobId}`)
-      updateSaveStateFromJob(cardId, job)
+      updateSaveStateFromJob(saveKey, job)
 
       while (!isTerminalStatus(job.status)) {
         if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
-          handleSaveFailed(cardId, 'Save timed out. Check your card in Yoto and try again.')
+          handleSaveFailed(
+            saveKey,
+            target.operation === 'create'
+              ? 'Create timed out. Check My Cards before trying again.'
+              : 'Save timed out. Check your card in Yoto and try again.',
+            target.operation === 'create',
+          )
           return
         }
 
         await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS))
         job = await $fetch<SaveJobState>(`/api/yoto/jobs/${jobId}`)
-        updateSaveStateFromJob(cardId, job)
+        updateSaveStateFromJob(saveKey, job)
       }
 
       if (job.status === 'failed') {
-        handleSaveFailed(cardId, job.error ?? 'Save failed')
+        handleSaveFailed(
+          saveKey,
+          job.error ?? 'Save failed',
+          target.operation === 'create' && job.outcomeUncertain === true,
+        )
         return
       }
 
-      await finalizeSaveSuccess(cardId, titleFallback)
+      let savedCardId: string
+      try {
+        savedCardId = resolveSavedCardId(
+          target.operation,
+          target.operation === 'update' ? target.cardId : null,
+          job.cardId,
+        )
+      }
+      catch (err: unknown) {
+        const e = err as { message?: string }
+        handleSaveFailed(
+          saveKey,
+          e.message ?? 'Failed to resolve saved card ID',
+          target.operation === 'create',
+        )
+        return
+      }
+
+      if (target.operation === 'create') {
+        promoteCreatedPlaylist(saveKey, savedCardId)
+      }
+      await finalizeSaveSuccess(savedCardId, titleFallback)
+      notifyConfirmedPlaylistCreated(target.operation, savedCardId, options.onPlaylistCreated)
     }
     catch (err: unknown) {
       const e = err as { statusCode?: number; statusMessage?: string; message?: string }
-      if (e.statusCode === 404) {
-        deleteSaveState(cardId)
-        removePersistedSave(cardId)
+      if (e.statusCode === 404 && target.operation === 'update') {
+        deleteSaveState(saveKey)
+        removePersistedSave(saveKey)
         return
       }
       handleSaveFailed(
-        cardId,
-        e.statusMessage ?? e.message ?? 'Failed to track save progress',
+        saveKey,
+        target.operation === 'create'
+          ? 'Could not confirm whether Yoto created this playlist. Check My Cards before trying again.'
+          : e.statusMessage ?? e.message ?? 'Failed to track save progress',
+        target.operation === 'create',
       )
     }
     finally {
@@ -333,12 +434,13 @@ export function useMyoEditor() {
   }
 
   async function startSaveJob(
-    cardId: string,
+    target: ClientSaveTarget,
     snapshot: CardSaveSnapshot,
     options?: { acknowledgeCapacityRisk?: boolean },
   ) {
+    const identity = resolveClientSaveTarget(target)
     const { jobId } = await $fetch<{ jobId: string }>(
-      `/api/yoto/content/${cardId}/save`,
+      identity.endpoint,
       {
         method: 'POST',
         body: {
@@ -352,7 +454,8 @@ export function useMyoEditor() {
 
     const startedAt = Date.now()
     const initialState: CardSaveState = {
-      cardId,
+      saveKey: identity.saveKey,
+      cardId: identity.operation === 'update' ? identity.cardId : undefined,
       jobId,
       status: 'planning',
       progress: 0,
@@ -361,11 +464,13 @@ export function useMyoEditor() {
       snapshot: cloneSnapshot(snapshot),
       startedAt,
     }
-    maxOverallProgressByCard.set(cardId, 0)
-    setSaveState(cardId, initialState)
-    addPersistedSave(cardId, jobId)
+    maxOverallProgressBySaveKey.set(identity.saveKey, 0)
+    setSaveState(identity.saveKey, initialState)
+    if (identity.operation === 'update') {
+      addPersistedSave(identity.cardId, jobId)
+    }
 
-    void pollSaveJob(cardId, jobId, snapshot.cardTitle)
+    void pollSaveJob(identity.saveKey, jobId, snapshot.cardTitle, identity)
   }
 
   async function hydratePersistedSaves() {
@@ -402,7 +507,8 @@ export function useMyoEditor() {
           errorMessage.value = ''
         }
 
-        void pollSaveJob(cardId, jobId, '')
+        const target = resolveClientSaveTarget({ operation: 'update', cardId })
+        void pollSaveJob(cardId, jobId, '', target)
       }
       catch (err: unknown) {
         const e = err as { statusCode?: number }
@@ -416,10 +522,12 @@ export function useMyoEditor() {
   async function selectCard(card: YotoMyoCard) {
     if (loading.value) return
 
-    const currentCardId = selectedCardId.value
-    const currentCardSaving = currentCardId ? isCardSaving(currentCardId) : false
+    const currentSaveKey = selectedSaveKey.value
+    const currentCardSaving = currentSaveKey ? isSaveActive(currentSaveKey) : false
 
-    if (currentCardId && isDirty.value && !currentCardSaving) {
+    if (isNewPlaylist.value && currentCardSaving) return
+
+    if (isEditing.value && isDirty.value && !currentCardSaving) {
       const confirmed = window.confirm(
         'You have unsaved playlist changes. Switch cards anyway?',
       )
@@ -432,6 +540,8 @@ export function useMyoEditor() {
 
     loading.value = true
     errorMessage.value = ''
+    createOutcomeUncertain.value = false
+    isNewPlaylist.value = false
     selectedCardId.value = card.cardId
     cardTitle.value = card.title
 
@@ -477,9 +587,33 @@ export function useMyoEditor() {
     }
   }
 
+  function startNewPlaylist(): boolean {
+    if (loading.value || (isNewPlaylist.value && isPlaylistLocked.value)) return false
+
+    const currentSaveKey = selectedSaveKey.value
+    const currentCardSaving = currentSaveKey ? isSaveActive(currentSaveKey) : false
+    if (isEditing.value && isDirty.value && !currentCardSaving) {
+      const confirmed = window.confirm(
+        'You have unsaved playlist changes. Start a new playlist anyway?',
+      )
+      if (!confirmed) return false
+    }
+
+    selectedCardId.value = null
+    isNewPlaylist.value = true
+    cardTitle.value = ''
+    isPodcast.value = false
+    playlist.value = []
+    baselinePlaylist.value = []
+    originalCardDetail.value = null
+    errorMessage.value = ''
+    createOutcomeUncertain.value = false
+    return true
+  }
+
   function clearSelection(force = false): boolean {
-    const currentCardId = selectedCardId.value
-    const currentCardSaving = currentCardId ? isCardSaving(currentCardId) : false
+    const currentSaveKey = selectedSaveKey.value
+    const currentCardSaving = currentSaveKey ? isSaveActive(currentSaveKey) : false
 
     if (!force && isDirty.value && !currentCardSaving) {
       const confirmed = window.confirm(
@@ -489,26 +623,33 @@ export function useMyoEditor() {
     }
 
     selectedCardId.value = null
+    isNewPlaylist.value = false
     cardTitle.value = ''
     isPodcast.value = false
     playlist.value = []
     baselinePlaylist.value = []
     originalCardDetail.value = null
     errorMessage.value = ''
+    createOutcomeUncertain.value = false
     return true
   }
 
   function resetChanges() {
     if (!isDirty.value || isPlaylistLocked.value) return
     playlist.value = clonePlaylist(baselinePlaylist.value)
+    if (isNewPlaylist.value) cardTitle.value = ''
     errorMessage.value = ''
+    if (isNewPlaylist.value) createOutcomeUncertain.value = false
   }
 
   function appendTracks(
     tracks: PlaylistTrack[],
   ): { ok: true, added: number } | { ok: false, message: string } {
-    if (!selectedCardId.value) {
-      return { ok: false, message: 'Select a MYO card before importing a playlist.' }
+    if (!isEditing.value) {
+      return {
+        ok: false,
+        message: 'Start a new playlist or select a MYO card before importing a playlist.',
+      }
     }
     if (loading.value || isPlaylistLocked.value) {
       return { ok: false, message: 'Wait for the current card operation to finish.' }
@@ -535,6 +676,50 @@ export function useMyoEditor() {
     playlist.value = [...playlist.value, ...clonePlaylist(tracks)]
     errorMessage.value = ''
     return { ok: true, added: tracks.length }
+  }
+
+  async function createPlaylist(options?: { acknowledgeCapacityRisk?: boolean }) {
+    if (
+      !isNewPlaylist.value
+      || loading.value
+      || isPlaylistLocked.value
+      || createOutcomeUncertain.value
+    ) return
+
+    const validationError = getStandalonePlaylistValidationError(cardTitle.value, playlist.value)
+    if (validationError) {
+      errorMessage.value = validationError
+      playEvent('saveError')
+      return
+    }
+
+    if (!options?.acknowledgeCapacityRisk) {
+      const limitError = getPlaylistPreflightLimitError(playlist.value)
+      if (limitError) {
+        errorMessage.value = limitError
+        playEvent('saveError')
+        return
+      }
+    }
+
+    errorMessage.value = ''
+    const snapshot: CardSaveSnapshot = {
+      playlist: clonePlaylist(playlist.value),
+      baseline: [],
+      cardTitle: cardTitle.value.trim(),
+    }
+
+    try {
+      await startSaveJob({ operation: 'create' }, snapshot, {
+        acknowledgeCapacityRisk: options?.acknowledgeCapacityRisk === true,
+      })
+    }
+    catch (err: unknown) {
+      const failure = classifyCreateStartFailure(err)
+      createOutcomeUncertain.value = failure.outcomeUncertain
+      errorMessage.value = failure.message
+      playEvent('saveError')
+    }
   }
 
   async function updateCard(options?: { acknowledgeCapacityRisk?: boolean }) {
@@ -564,7 +749,7 @@ export function useMyoEditor() {
     }
 
     try {
-      await startSaveJob(cardId, snapshot, {
+      await startSaveJob({ operation: 'update', cardId }, snapshot, {
         acknowledgeCapacityRisk: options?.acknowledgeCapacityRisk === true,
       })
     }
@@ -574,12 +759,42 @@ export function useMyoEditor() {
     }
   }
 
+  function onBeforeUnload(event: BeforeUnloadEvent) {
+    event.preventDefault()
+    event.returnValue = true
+  }
+
+  let stopBeforeUnloadWatch: (() => void) | null = null
+  let beforeUnloadAttached = false
+
   onMounted(() => {
+    stopBeforeUnloadWatch = watch(
+      [isDirty, isPlaylistLocked],
+      ([dirty, locked]) => {
+        const shouldAttach = shouldWarnBeforeUnload(dirty, locked)
+        if (shouldAttach === beforeUnloadAttached) return
+
+        window[shouldAttach ? 'addEventListener' : 'removeEventListener'](
+          'beforeunload',
+          onBeforeUnload,
+        )
+        beforeUnloadAttached = shouldAttach
+      },
+      { immediate: true },
+    )
     void hydratePersistedSaves()
+  })
+
+  onUnmounted(() => {
+    stopBeforeUnloadWatch?.()
+    if (beforeUnloadAttached) {
+      window.removeEventListener('beforeunload', onBeforeUnload)
+    }
   })
 
   return {
     selectedCardId,
+    isNewPlaylist,
     cardTitle,
     playlist,
     isEditing,
@@ -589,12 +804,15 @@ export function useMyoEditor() {
     isPlaylistLocked,
     saveProgress,
     errorMessage,
+    createOutcomeUncertain,
     isDirty,
     isCardSaving,
+    startNewPlaylist,
     selectCard,
     clearSelection,
     resetChanges,
     appendTracks,
+    createPlaylist,
     updateCard,
   }
 }

--- a/app/components/myo-editor/useMyoEditor.ts
+++ b/app/components/myo-editor/useMyoEditor.ts
@@ -10,7 +10,10 @@ import {
   removePersistedSave,
 } from './saveJobPersistence'
 import type { SaveJobState, YotoCardDetail } from './types'
-import { getPlaylistPreflightLimitError } from '#shared/myo-editor/yotoMyoLimits'
+import {
+  getPlaylistPreflightLimitError,
+  getTrackCountLimitError,
+} from '#shared/myo-editor/yotoMyoLimits'
 
 export interface SaveProgress {
   phase: SaveJobState['status']
@@ -54,6 +57,7 @@ export interface MyoEditorContext {
   selectCard: (card: YotoMyoCard) => Promise<void>
   clearSelection: (force?: boolean) => boolean
   resetChanges: () => void
+  appendTracks: (tracks: PlaylistTrack[]) => { ok: true, added: number } | { ok: false, message: string }
   updateCard: (options?: { acknowledgeCapacityRisk?: boolean }) => Promise<void>
 }
 
@@ -500,6 +504,39 @@ export function useMyoEditor() {
     errorMessage.value = ''
   }
 
+  function appendTracks(
+    tracks: PlaylistTrack[],
+  ): { ok: true, added: number } | { ok: false, message: string } {
+    if (!selectedCardId.value) {
+      return { ok: false, message: 'Select a MYO card before importing a playlist.' }
+    }
+    if (loading.value || isPlaylistLocked.value) {
+      return { ok: false, message: 'Wait for the current card operation to finish.' }
+    }
+
+    const countError = getTrackCountLimitError(playlist.value.length + tracks.length)
+    if (countError) return { ok: false, message: countError }
+
+    const existingKeys = new Set(
+      playlist.value.map(track => track.youtubeId ? `youtube:${track.youtubeId}` : `track:${track.id}`),
+    )
+    const incomingKeys = new Set<string>()
+    for (const track of tracks) {
+      const key = track.youtubeId ? `youtube:${track.youtubeId}` : `track:${track.id}`
+      if (existingKeys.has(key) || incomingKeys.has(key)) {
+        return {
+          ok: false,
+          message: 'The playlist changed while you were reviewing it. Review duplicate tracks and try again.',
+        }
+      }
+      incomingKeys.add(key)
+    }
+
+    playlist.value = [...playlist.value, ...clonePlaylist(tracks)]
+    errorMessage.value = ''
+    return { ok: true, added: tracks.length }
+  }
+
   async function updateCard(options?: { acknowledgeCapacityRisk?: boolean }) {
     const cardId = selectedCardId.value
     if (!cardId || !isDirty.value || loading.value || isPlaylistLocked.value) return
@@ -557,6 +594,7 @@ export function useMyoEditor() {
     selectCard,
     clearSelection,
     resetChanges,
+    appendTracks,
     updateCard,
   }
 }

--- a/app/components/playlist/PlaylistCapacityMeters.vue
+++ b/app/components/playlist/PlaylistCapacityMeters.vue
@@ -9,11 +9,11 @@ import {
 
 const editor = inject(MYO_EDITOR_KEY, null)
 const playlist = editor?.playlist
-const selectedCardId = editor?.selectedCardId
+const isEditing = editor?.isEditing
 
 const capacity = computed(() => getPlaylistCapacitySnapshot(playlist?.value ?? []))
 
-const show = computed(() => Boolean(selectedCardId?.value))
+const show = computed(() => Boolean(isEditing?.value))
 
 const trackRatio = computed(() => {
   const { trackCount, trackMax } = capacity.value

--- a/app/components/playlist/PlaylistPanelFooter.vue
+++ b/app/components/playlist/PlaylistPanelFooter.vue
@@ -6,6 +6,10 @@ import {
   getPlaylistCapacitySnapshot,
   YOTO_MYO_TRACK_COUNT_MESSAGE,
 } from '#shared/myo-editor/yotoMyoLimits'
+import {
+  getStandalonePlaylistValidationError,
+  UNCERTAIN_CREATE_START_MESSAGE,
+} from '#shared/myo-editor/standalonePlaylist'
 
 const editor = inject(MYO_EDITOR_KEY, null)
 const { playEvent } = useUiSound()
@@ -16,8 +20,11 @@ const isDirty = editor?.isDirty
 const loading = editor?.loading
 const isPlaylistLocked = editor?.isPlaylistLocked
 const selectedCardId = editor?.selectedCardId
+const isNewPlaylist = editor?.isNewPlaylist
+const cardTitle = editor?.cardTitle
 const isPodcast = editor?.isPodcast
 const errorMessage = editor?.errorMessage
+const createOutcomeUncertain = editor?.createOutcomeUncertain
 const playlist = editor?.playlist
 
 const showCapacityConfirm = ref(false)
@@ -36,23 +43,44 @@ const overTrackLimit = computed(
   () => capacity.value.trackCount > capacity.value.trackMax,
 )
 
+const createValidationError = computed(() =>
+  isNewPlaylist?.value
+    ? getStandalonePlaylistValidationError(cardTitle?.value ?? '', playlist?.value ?? [])
+    : null,
+)
+
 const footerHint = computed(() => {
   if (isPodcast?.value) return 'Podcast cards cannot be edited yet.'
+  if (createOutcomeUncertain?.value) {
+    return errorMessage?.value || UNCERTAIN_CREATE_START_MESSAGE
+  }
   if (errorMessage?.value) return errorMessage.value
+  if (createValidationError.value) return createValidationError.value
   if (overTrackLimit.value) return YOTO_MYO_TRACK_COUNT_MESSAGE
   return ''
 })
 
-const canUpdate = computed(
-  () => Boolean(
-    selectedCardId?.value
-    && isDirty?.value
-    && !loading?.value
+const canSave = computed(() => {
+  const ready = Boolean(
+    !loading?.value
     && !isPlaylistLocked?.value
     && !saveProgressTestMode.value
     && !isPodcast?.value,
-  ),
-)
+  )
+  if (!ready) return false
+  if (isNewPlaylist?.value) {
+    return !createValidationError.value && !createOutcomeUncertain?.value
+  }
+  return Boolean(selectedCardId?.value && isDirty?.value)
+})
+
+const actionLabel = computed(() => {
+  if (isPlaylistLocked?.value || saveProgressTestMode.value) {
+    return isNewPlaylist?.value ? 'Creating...' : 'Updating...'
+  }
+  if (isNewPlaylist?.value && createOutcomeUncertain?.value) return 'Check My Cards'
+  return isNewPlaylist?.value ? 'Create' : 'Update'
+})
 
 const canReset = computed(
   () => Boolean(isDirty?.value && !loading?.value && !isPlaylistLocked?.value && !saveProgressTestMode.value),
@@ -62,8 +90,16 @@ function closeCapacityConfirm() {
   showCapacityConfirm.value = false
 }
 
-function onUpdate() {
-  if (!canUpdate.value) {
+function savePlaylist(options?: { acknowledgeCapacityRisk?: boolean }) {
+  if (isNewPlaylist?.value) {
+    void editor?.createPlaylist(options)
+    return
+  }
+  void editor?.updateCard(options)
+}
+
+function onSave() {
+  if (!canSave.value) {
     playEvent('disabled')
     return
   }
@@ -75,20 +111,20 @@ function onUpdate() {
   }
 
   playEvent('buttonPrimary')
-  void editor?.updateCard()
+  savePlaylist()
 }
 
-function onConfirmRiskyUpdate() {
-  if (!canUpdate.value) {
+function onConfirmRiskySave() {
+  if (!canSave.value) {
     playEvent('disabled')
     return
   }
   playEvent('buttonPrimary')
   closeCapacityConfirm()
-  void editor?.updateCard({ acknowledgeCapacityRisk: true })
+  savePlaylist({ acknowledgeCapacityRisk: true })
 }
 
-function onCancelRiskyUpdate() {
+function onCancelRiskySave() {
   playEvent('resetPlaylist')
   closeCapacityConfirm()
 }
@@ -106,12 +142,12 @@ function onReset() {
 watch(
   () => [
     overCapacity.value,
-    canUpdate.value,
+    canSave.value,
     isPlaylistLocked?.value,
     saveProgressTestMode.value,
   ],
   () => {
-    if (!overCapacity.value || !canUpdate.value || isPlaylistLocked?.value || saveProgressTestMode.value) {
+    if (!overCapacity.value || !canSave.value || isPlaylistLocked?.value || saveProgressTestMode.value) {
       closeCapacityConfirm()
     }
   },
@@ -143,11 +179,11 @@ watch(
           <button
             type="button"
             class="panel-footer-btn panel-footer-btn--short panel-footer-btn--primary shrink-0"
-            :aria-disabled="!canUpdate"
-            :tabindex="canUpdate ? 0 : -1"
-            @click="onUpdate"
+            :aria-disabled="!canSave"
+            :tabindex="canSave ? 0 : -1"
+            @click="onSave"
           >
-            <span class="panel-footer-btn__label">{{ isPlaylistLocked?.value || saveProgressTestMode ? 'Updating...' : 'Update' }}</span>
+            <span class="panel-footer-btn__label">{{ actionLabel }}</span>
           </button>
         </div>
       </div>
@@ -166,22 +202,22 @@ watch(
         id="footer-capacity-confirm-title"
         class="footer-capacity-confirm__copy font-maru-mono text-pretty"
       >
-        Over MYO limit — update may fail.
+        Over MYO limit — {{ isNewPlaylist ? 'create' : 'update' }} may fail.
       </p>
       <div class="footer-capacity-confirm__actions">
         <button
           type="button"
           class="panel-footer-btn panel-footer-btn--short panel-footer-btn--secondary shrink-0"
-          @click="onCancelRiskyUpdate"
+          @click="onCancelRiskySave"
         >
           <span class="panel-footer-btn__label">Cancel</span>
         </button>
         <button
           type="button"
           class="panel-footer-btn panel-footer-btn--short panel-footer-btn--primary shrink-0"
-          @click="onConfirmRiskyUpdate"
+          @click="onConfirmRiskySave"
         >
-          <span class="panel-footer-btn__label">Update anyway</span>
+          <span class="panel-footer-btn__label">{{ isNewPlaylist ? 'Create' : 'Update' }} anyway</span>
         </button>
       </div>
     </div>

--- a/app/components/playlist/YoutubePlaylist.vue
+++ b/app/components/playlist/YoutubePlaylist.vue
@@ -29,7 +29,16 @@ if (!editor) {
 
 const yoto = inject(YOTO_MYO_KEY, null)
 
-const { playlist, isPlaylistLocked, saveProgress, loading, cardTitle, selectedCardId, clearSelection } = editor
+const {
+  playlist,
+  isEditing,
+  isPlaylistLocked,
+  saveProgress,
+  loading,
+  cardTitle,
+  selectedCardId,
+  clearSelection,
+} = editor
 
 const saveProgressTestMode = useSaveProgressTestMode()
 
@@ -261,7 +270,7 @@ const { isDropTarget } = useDroppable({
     () => isDropzoneLocked.value
       || isCardLoadingActive.value
       || isYotoPlaylistBlocked.value
-      || !selectedCardId.value,
+      || !isEditing.value,
   ),
 })
 
@@ -306,7 +315,7 @@ watch(() => props.scrollToVideoId, async (id) => {
     ref="element"
     class="playlist-dropzone relative flex flex-col flex-1 min-h-0 h-full w-full overflow-hidden transition-[background-color,box-shadow]"
     :class="[
-      isDropTarget && !isDropzoneLocked && !isCardLoadingActive && !isYotoPlaylistBlocked && selectedCardId
+      isDropTarget && !isDropzoneLocked && !isCardLoadingActive && !isYotoPlaylistBlocked && isEditing
         ? 'bg-maru-green-light ring-2 ring-inset ring-maru-blue'
         : '',
       isDropzoneLocked ? 'playlist-dropzone--locked' : '',
@@ -315,7 +324,7 @@ watch(() => props.scrollToVideoId, async (id) => {
   >
     <div
       class="playlist-dropzone__scroll flex flex-col flex-1 min-h-0 overflow-y-auto p-3 sm:p-4"
-      :class="isDropzoneLocked || isCardLoadingActive || isYotoPlaylistBlocked || !selectedCardId ? 'pointer-events-none select-none' : ''"
+      :class="isDropzoneLocked || isCardLoadingActive || isYotoPlaylistBlocked || !isEditing ? 'pointer-events-none select-none' : ''"
     >
       <TransitionGroup
         v-if="showPlaylistItems"

--- a/app/components/yoto-myo/index.vue
+++ b/app/components/yoto-myo/index.vue
@@ -25,7 +25,9 @@ const yoto = inject(YOTO_MYO_KEY, null) ?? useYotoMyo()
 const editor = inject(MYO_EDITOR_KEY, null)
 
 const selectedCardId = editor?.selectedCardId
+const isNewPlaylist = editor?.isNewPlaylist
 const editorLoading = editor?.loading
+const editorLocked = editor?.isPlaylistLocked
 
 const {
   cards,
@@ -50,6 +52,14 @@ function onSelectCard(card: YotoMyoCardType) {
   if (shouldSuppressCardClick()) return
   editor?.selectCard(card)
 }
+
+function onNewPlaylist() {
+  editor?.startNewPlaylist()
+}
+
+const newPlaylistDisabled = computed(
+  () => Boolean(editorLoading?.value || (isNewPlaylist?.value && editorLocked?.value)),
+)
 
 const cardCountLabel = computed(() => {
   if (!connected.value || status.value !== 'idle') return ''
@@ -107,6 +117,19 @@ watch(cardCountLabel, value => emit('update:count', value), { immediate: true })
       </div>
 
       <template v-else>
+        <div class="mb-3 flex justify-end">
+          <button
+            type="button"
+            class="maru-button maru-button--sm"
+            :class="isNewPlaylist ? 'bg-maru-blue text-maru-white' : 'bg-maru-white text-maru-black'"
+            :disabled="newPlaylistDisabled"
+            :aria-pressed="isNewPlaylist || undefined"
+            @click="onNewPlaylist"
+          >
+            <span class="maru-button__label">New Playlist</span>
+          </button>
+        </div>
+
         <p
           v-if="cards.length === 0"
           class="empty-state-meta py-8 text-center"
@@ -190,6 +213,19 @@ watch(cardCountLabel, value => emit('update:count', value), { immediate: true })
       </div>
 
       <template v-else>
+        <div class="shrink-0 px-3 pt-3 sm:px-4 sm:pt-4">
+          <button
+            type="button"
+            class="maru-button maru-button--sm w-full"
+            :class="isNewPlaylist ? 'bg-maru-blue text-maru-white' : 'bg-maru-white text-maru-black'"
+            :disabled="newPlaylistDisabled"
+            :aria-pressed="isNewPlaylist || undefined"
+            @click="onNewPlaylist"
+          >
+            <span class="maru-button__label">New Playlist</span>
+          </button>
+        </div>
+
         <p
           v-if="cards.length === 0"
           class="empty-state flex-1 min-h-0 w-full empty-state-meta"

--- a/app/components/yoto-myo/useYotoMyo.ts
+++ b/app/components/yoto-myo/useYotoMyo.ts
@@ -1,4 +1,9 @@
 import type { YotoAuthStatus, YotoContentMineResponse, YotoMyoCard, YotoMyoStatus } from './types'
+import { shouldPreserveAuxiliaryRefreshState } from '#shared/yoto/refreshPolicy'
+
+interface RefreshOptions {
+  auxiliary?: boolean
+}
 
 function extractErrorMessage(err: unknown): string {
   const fetchErr = err as {
@@ -22,7 +27,9 @@ export function useYotoMyo() {
   const connected = ref(false)
   const hasWriteScope = ref(false)
 
-  async function fetchCards() {
+  async function fetchCards(options: RefreshOptions = {}) {
+    const previousCards = cards.value
+    const wasConnected = connected.value
     status.value = 'loading'
     errorMessage.value = ''
 
@@ -34,6 +41,18 @@ export function useYotoMyo() {
     catch (err: unknown) {
       const fetchErr = err as { statusCode?: number }
       errorMessage.value = extractErrorMessage(err)
+
+      if (
+        shouldPreserveAuxiliaryRefreshState(
+          options.auxiliary === true,
+          wasConnected,
+          fetchErr.statusCode,
+        )
+      ) {
+        cards.value = previousCards
+        status.value = 'idle'
+        return
+      }
 
       if (fetchErr.statusCode === 401) {
         connected.value = false
@@ -47,7 +66,9 @@ export function useYotoMyo() {
     }
   }
 
-  async function checkStatus() {
+  async function checkStatus(options: RefreshOptions = {}) {
+    const previousCards = cards.value
+    const wasConnected = connected.value
     status.value = 'loading'
     errorMessage.value = ''
 
@@ -69,10 +90,24 @@ export function useYotoMyo() {
         return
       }
 
-      await fetchCards()
+      await fetchCards(options)
     }
     catch (err: unknown) {
+      const fetchErr = err as { statusCode?: number }
       errorMessage.value = extractErrorMessage(err)
+
+      if (
+        shouldPreserveAuxiliaryRefreshState(
+          options.auxiliary === true,
+          wasConnected,
+          fetchErr.statusCode,
+        )
+      ) {
+        cards.value = previousCards
+        status.value = 'idle'
+        return
+      }
+
       status.value = 'error'
     }
   }
@@ -100,6 +135,10 @@ export function useYotoMyo() {
     await checkStatus()
   }
 
+  async function refreshAfterCreate() {
+    await checkStatus({ auxiliary: true })
+  }
+
   onMounted(() => {
     checkStatus()
   })
@@ -114,6 +153,7 @@ export function useYotoMyo() {
     connect,
     disconnect,
     refresh,
+    refreshAfterCreate,
     fetchCards,
   }
 }

--- a/app/components/youtube-picker/YoutubePlaylistImport.vue
+++ b/app/components/youtube-picker/YoutubePlaylistImport.vue
@@ -40,7 +40,7 @@ const pageErrorMessage = ref('')
 const inputRef = ref<HTMLInputElement | null>(null)
 
 const canOpen = computed(
-  () => Boolean(editor?.selectedCardId.value) && !editor?.isPlaylistLocked.value,
+  () => Boolean(editor?.isEditing.value) && !editor?.isPlaylistLocked.value,
 )
 
 const evaluation = computed(() =>
@@ -257,7 +257,7 @@ onUnmounted(() => document.removeEventListener('keydown', onKeydown))
       type="button"
       class="maru-button maru-button--sm bg-maru-yellow text-maru-black"
       :disabled="!canOpen"
-      :title="canOpen ? 'Import tracks from a public YouTube playlist' : 'Select a MYO card first'"
+      :title="canOpen ? 'Import tracks from a public YouTube playlist' : 'Start a new playlist or select a MYO card first'"
       @click="show"
     >
       <span class="maru-button__label">Import playlist</span>

--- a/app/components/youtube-picker/YoutubePlaylistImport.vue
+++ b/app/components/youtube-picker/YoutubePlaylistImport.vue
@@ -1,0 +1,682 @@
+<script setup lang="ts">
+import { MYO_EDITOR_KEY } from '~/components/myo-editor/keys'
+import { pickerVideoToPlaylistTrack } from '~/components/playlist/types'
+import {
+  evaluateYoutubePlaylistImport,
+  parseYoutubePlaylistUrl,
+  preselectYoutubePlaylistImport,
+  type YoutubePlaylistImportBlockReason,
+  type YoutubePlaylistImportItem,
+  type YoutubePlaylistImportResponse,
+  type YoutubePlaylistSummary,
+} from '#shared/myo-editor/youtubePlaylistImport'
+import { formatDurationSeconds } from '#shared/myo-editor/youtubeDuration'
+
+const BLOCK_REASON_LABELS: Record<YoutubePlaylistImportBlockReason, string> = {
+  unavailable: 'Unavailable',
+  'missing-duration': 'Missing duration',
+  'over-track-duration': 'Over 60 minutes',
+  'duplicate-existing': 'Already on this card',
+  'duplicate-source': 'Repeated in source playlist',
+  'track-capacity': 'Card track limit',
+  'duration-capacity': 'Card time limit',
+}
+
+const editor = inject(MYO_EDITOR_KEY, null)
+const { allowLongTracks, setAllowLongTracks } = useUserPreferences()
+const { playEvent } = useUiSound()
+
+const open = ref(false)
+const url = ref('')
+const playlist = ref<YoutubePlaylistSummary | null>(null)
+const items = ref<YoutubePlaylistImportItem[]>([])
+const selectedKeys = ref(new Set<string>())
+const nextPageToken = ref<string | undefined>()
+const loading = ref(false)
+const loadingMore = ref(false)
+const appending = ref(false)
+const errorMessage = ref('')
+const pageErrorMessage = ref('')
+const inputRef = ref<HTMLInputElement | null>(null)
+
+const canOpen = computed(
+  () => Boolean(editor?.selectedCardId.value) && !editor?.isPlaylistLocked.value,
+)
+
+const evaluation = computed(() =>
+  evaluateYoutubePlaylistImport(
+    items.value,
+    editor?.playlist.value ?? [],
+    selectedKeys.value,
+    allowLongTracks.value,
+  ),
+)
+
+const selectedDurationLabel = computed(
+  () => formatDurationSeconds(evaluation.value.selectedDurationSeconds),
+)
+
+function resetImport() {
+  url.value = ''
+  playlist.value = null
+  items.value = []
+  selectedKeys.value = new Set()
+  nextPageToken.value = undefined
+  loading.value = false
+  loadingMore.value = false
+  appending.value = false
+  errorMessage.value = ''
+  pageErrorMessage.value = ''
+}
+
+async function show() {
+  if (!canOpen.value) {
+    playEvent('disabled')
+    return
+  }
+  resetImport()
+  open.value = true
+  playEvent('buttonClick')
+  await nextTick()
+  inputRef.value?.focus()
+}
+
+function close() {
+  if (loading.value || loadingMore.value || appending.value) return
+  open.value = false
+  playEvent('toggleOff')
+}
+
+function fetchErrorMessage(err: unknown, fallback: string): string {
+  const fetchErr = err as {
+    statusMessage?: string
+    data?: { message?: string, statusMessage?: string }
+    message?: string
+  }
+  return fetchErr.data?.message
+    ?? fetchErr.data?.statusMessage
+    ?? fetchErr.statusMessage
+    ?? fetchErr.message
+    ?? fallback
+}
+
+async function fetchPage(playlistId: string, pageToken?: string) {
+  return await $fetch<YoutubePlaylistImportResponse>('/api/youtube/playlist', {
+    query: { playlistId, pageToken },
+  })
+}
+
+async function loadPlaylist() {
+  const playlistId = parseYoutubePlaylistUrl(url.value)
+  if (!playlistId) {
+    errorMessage.value = 'Paste a full HTTPS YouTube playlist URL.'
+    return
+  }
+
+  loading.value = true
+  errorMessage.value = ''
+  pageErrorMessage.value = ''
+  playlist.value = null
+  items.value = []
+  selectedKeys.value = new Set()
+  nextPageToken.value = undefined
+
+  try {
+    const data = await fetchPage(playlistId)
+    playlist.value = data.playlist ?? null
+    items.value = data.items
+    nextPageToken.value = data.nextPageToken
+    selectedKeys.value = preselectYoutubePlaylistImport(
+      items.value,
+      editor?.playlist.value ?? [],
+      allowLongTracks.value,
+    ).selectedKeys
+    playEvent('loadMoreComplete')
+  }
+  catch (err: unknown) {
+    errorMessage.value = fetchErrorMessage(err, 'Failed to load YouTube playlist')
+  }
+  finally {
+    loading.value = false
+  }
+}
+
+async function loadMore() {
+  const playlistId = parseYoutubePlaylistUrl(url.value)
+  const token = nextPageToken.value
+  if (!playlistId || !token || loadingMore.value) return
+
+  loadingMore.value = true
+  pageErrorMessage.value = ''
+  try {
+    const data = await fetchPage(playlistId, token)
+    const requested = new Set(selectedKeys.value)
+    for (const item of data.items) requested.add(item.playlistItemId)
+    items.value = [...items.value, ...data.items]
+    nextPageToken.value = data.nextPageToken
+    selectedKeys.value = evaluateYoutubePlaylistImport(
+      items.value,
+      editor?.playlist.value ?? [],
+      requested,
+      allowLongTracks.value,
+    ).selectedKeys
+    playEvent('loadMoreComplete')
+  }
+  catch (err: unknown) {
+    pageErrorMessage.value = fetchErrorMessage(err, 'Failed to load the next page')
+  }
+  finally {
+    loadingMore.value = false
+  }
+}
+
+function toggleItem(
+  playlistItemId: string,
+  selected: boolean,
+  blockReason?: YoutubePlaylistImportBlockReason,
+) {
+  if (blockReason && !selected) {
+    playEvent('disabled')
+    return
+  }
+
+  const requested = new Set(selectedKeys.value)
+  if (selected) requested.delete(playlistItemId)
+  else requested.add(playlistItemId)
+
+  selectedKeys.value = evaluateYoutubePlaylistImport(
+    items.value,
+    editor?.playlist.value ?? [],
+    requested,
+    allowLongTracks.value,
+  ).selectedKeys
+  playEvent(selected ? 'toggleOff' : 'toggleOn')
+}
+
+function enableLongTracks() {
+  setAllowLongTracks(true)
+  playEvent('toggleOn')
+}
+
+function appendSelected() {
+  if (!editor || appending.value) return
+
+  const latest = evaluateYoutubePlaylistImport(
+    items.value,
+    editor.playlist.value,
+    selectedKeys.value,
+    allowLongTracks.value,
+  )
+  selectedKeys.value = latest.selectedKeys
+  if (latest.selectedCount === 0) {
+    errorMessage.value = 'Select at least one available track to import.'
+    return
+  }
+
+  appending.value = true
+  errorMessage.value = ''
+  const tracks = latest.items
+    .filter(entry => entry.selected)
+    .map(({ item }) =>
+      pickerVideoToPlaylistTrack({
+        id: item.videoId,
+        title: item.title,
+        channelTitle: item.channelTitle,
+        thumbnailUrl: item.thumbnailUrl,
+        publishedAt: '',
+        duration: item.duration,
+        durationSeconds: item.durationSeconds,
+      }),
+    )
+  const result = editor.appendTracks(tracks)
+  appending.value = false
+
+  if (!result.ok) {
+    errorMessage.value = result.message
+    return
+  }
+
+  playEvent('drop')
+  open.value = false
+}
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape' && open.value) {
+    event.preventDefault()
+    close()
+  }
+}
+
+onMounted(() => document.addEventListener('keydown', onKeydown))
+onUnmounted(() => document.removeEventListener('keydown', onKeydown))
+</script>
+
+<template>
+  <div class="playlist-import-launch">
+    <button
+      type="button"
+      class="maru-button maru-button--sm bg-maru-yellow text-maru-black"
+      :disabled="!canOpen"
+      :title="canOpen ? 'Import tracks from a public YouTube playlist' : 'Select a MYO card first'"
+      @click="show"
+    >
+      <span class="maru-button__label">Import playlist</span>
+    </button>
+  </div>
+
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="playlist-import"
+      @click.self="close"
+    >
+      <section
+        class="playlist-import__dialog border-maru rounded-maru bg-maru-white"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="playlist-import-title"
+      >
+        <header class="playlist-import__header border-maru-bottom">
+          <div>
+            <h2
+              id="playlist-import-title"
+              class="font-maru-bold"
+            >
+              Import a YouTube playlist
+            </h2>
+            <p class="font-maru-mono">
+              Public playlists only. Review every track before adding it.
+            </p>
+          </div>
+          <button
+            type="button"
+            class="playlist-import__close font-maru-mono"
+            aria-label="Close playlist import"
+            :disabled="loading || loadingMore || appending"
+            @click="close"
+          >
+            ×
+          </button>
+        </header>
+
+        <div class="playlist-import__body">
+          <form
+            class="playlist-import__form"
+            @submit.prevent="loadPlaylist"
+          >
+            <label
+              for="playlist-import-url"
+              class="font-maru-mono"
+            >YouTube playlist URL</label>
+            <div class="playlist-import__url-row">
+              <input
+                id="playlist-import-url"
+                ref="inputRef"
+                v-model="url"
+                type="url"
+                inputmode="url"
+                autocomplete="off"
+                placeholder="https://www.youtube.com/playlist?list=…"
+                :disabled="loading || items.length > 0"
+              >
+              <button
+                type="submit"
+                class="maru-button maru-button--sm bg-maru-blue text-maru-white"
+                :disabled="loading || items.length > 0"
+              >
+                <span class="maru-button__label">{{ loading ? 'Loading…' : 'Review' }}</span>
+              </button>
+            </div>
+          </form>
+
+          <p
+            v-if="errorMessage"
+            class="playlist-import__error font-maru-mono"
+            role="alert"
+          >
+            {{ errorMessage }}
+          </p>
+
+          <div
+            v-if="playlist"
+            class="playlist-import__summary"
+          >
+            <div>
+              <h3 class="font-maru-bold">{{ playlist.title }}</h3>
+              <p class="font-maru-mono">
+                {{ playlist.channelTitle }}
+                <template v-if="playlist.itemCount !== undefined">
+                  · {{ playlist.itemCount }} source tracks
+                </template>
+              </p>
+            </div>
+            <p class="font-maru-mono">
+              {{ evaluation.selectedCount }} selected
+              <template v-if="selectedDurationLabel">
+                · {{ selectedDurationLabel }}
+              </template>
+            </p>
+          </div>
+
+          <ul
+            v-if="items.length > 0"
+            class="playlist-import__items"
+          >
+            <li
+              v-for="entry in evaluation.items"
+              :key="entry.item.playlistItemId"
+              class="playlist-import__item"
+              :class="{ 'playlist-import__item--blocked': entry.blockReason }"
+            >
+              <label>
+                <input
+                  type="checkbox"
+                  :checked="entry.selected"
+                  :disabled="Boolean(entry.blockReason) && !entry.selected"
+                  @change="toggleItem(entry.item.playlistItemId, entry.selected, entry.blockReason)"
+                >
+                <img
+                  v-if="entry.item.thumbnailUrl"
+                  :src="entry.item.thumbnailUrl"
+                  alt=""
+                  loading="lazy"
+                >
+                <span class="playlist-import__item-copy">
+                  <strong class="font-maru-medium">{{ entry.item.title }}</strong>
+                  <span class="font-maru-mono">
+                    {{ entry.item.channelTitle }}
+                    <template v-if="entry.item.durationSeconds">
+                      · {{ formatDurationSeconds(entry.item.durationSeconds) }}
+                    </template>
+                  </span>
+                </span>
+                <span
+                  v-if="entry.blockReason"
+                  class="playlist-import__reason font-maru-mono"
+                >
+                  {{ BLOCK_REASON_LABELS[entry.blockReason] }}
+                </span>
+              </label>
+            </li>
+          </ul>
+
+          <div
+            v-if="items.length > 0 && !allowLongTracks && evaluation.items.some(entry => entry.blockReason === 'over-track-duration')"
+            class="playlist-import__long-tracks font-maru-mono"
+          >
+            <span>Some tracks are over Yoto’s 60-minute per-track limit.</span>
+            <button
+              type="button"
+              @click="enableLongTracks"
+            >
+              Allow for this session
+            </button>
+          </div>
+
+          <p
+            v-if="pageErrorMessage"
+            class="playlist-import__error font-maru-mono"
+            role="alert"
+          >
+            {{ pageErrorMessage }}
+          </p>
+
+          <button
+            v-if="nextPageToken"
+            type="button"
+            class="playlist-import__load-more font-maru-mono"
+            :disabled="loadingMore"
+            @click="loadMore"
+          >
+            {{ loadingMore ? 'Loading more…' : 'Load 50 more' }}
+          </button>
+        </div>
+
+        <footer class="playlist-import__footer border-maru-top">
+          <button
+            type="button"
+            class="maru-button maru-button--sm bg-maru-white text-maru-black"
+            :disabled="loading || loadingMore || appending"
+            @click="close"
+          >
+            <span class="maru-button__label">Cancel</span>
+          </button>
+          <button
+            type="button"
+            class="maru-button maru-button--sm bg-maru-green-light text-maru-black"
+            :disabled="evaluation.selectedCount === 0 || loading || loadingMore || appending"
+            @click="appendSelected"
+          >
+            <span class="maru-button__label">
+              Add {{ evaluation.selectedCount || '' }} track{{ evaluation.selectedCount === 1 ? '' : 's' }}
+            </span>
+          </button>
+        </footer>
+      </section>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.playlist-import-launch {
+  display: flex;
+  justify-content: flex-end;
+  padding: .5rem 0 .75rem;
+}
+
+.playlist-import-launch button:disabled {
+  cursor: not-allowed;
+  opacity: .45;
+}
+
+.playlist-import {
+  position: fixed;
+  inset: 0;
+  z-index: 130;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgb(0 0 0 / .55);
+}
+
+.playlist-import__dialog {
+  display: flex;
+  width: min(58rem, 100%);
+  max-height: min(52rem, calc(100vh - 2rem));
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: .5rem .5rem 0 rgb(0 0 0 / .25);
+}
+
+.playlist-import__header,
+.playlist-import__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+}
+
+.playlist-import__header h2,
+.playlist-import__header p,
+.playlist-import__summary h3,
+.playlist-import__summary p {
+  margin: 0;
+}
+
+.playlist-import__header h2 {
+  font-size: 2rem;
+  line-height: .9;
+}
+
+.playlist-import__header p,
+.playlist-import__summary p {
+  margin-top: .35rem;
+  font-size: .85rem;
+}
+
+.playlist-import__close {
+  border: 0;
+  background: transparent;
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.playlist-import__body {
+  min-height: 0;
+  overflow-y: auto;
+  padding: 1rem 1.25rem;
+}
+
+.playlist-import__form label {
+  display: block;
+  margin-bottom: .35rem;
+  font-size: .85rem;
+}
+
+.playlist-import__url-row {
+  display: flex;
+  gap: .65rem;
+}
+
+.playlist-import__url-row input {
+  min-width: 0;
+  flex: 1;
+  border: 2px solid currentcolor;
+  border-radius: var(--radius-maru);
+  padding: .65rem .75rem;
+  background: white;
+  font-family: var(--font-maru-mono);
+}
+
+.playlist-import__error {
+  margin: .75rem 0 0;
+  border-radius: var(--radius-maru);
+  padding: .65rem .75rem;
+  background: var(--color-maru-red-lighter);
+  color: var(--color-maru-red);
+}
+
+.playlist-import__summary {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.playlist-import__summary h3 {
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.playlist-import__items {
+  display: grid;
+  gap: .4rem;
+  margin: 1rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.playlist-import__item {
+  border: 2px solid rgb(0 0 0 / .16);
+  border-radius: var(--radius-maru);
+}
+
+.playlist-import__item--blocked {
+  opacity: .6;
+}
+
+.playlist-import__item label {
+  display: grid;
+  grid-template-columns: auto 5.5rem minmax(0, 1fr) auto;
+  align-items: center;
+  gap: .65rem;
+  padding: .5rem;
+  cursor: pointer;
+}
+
+.playlist-import__item input {
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+.playlist-import__item img {
+  width: 5.5rem;
+  aspect-ratio: 16 / 9;
+  border-radius: calc(var(--radius-maru) - 3px);
+  object-fit: cover;
+}
+
+.playlist-import__item-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.playlist-import__item-copy strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.playlist-import__item-copy span,
+.playlist-import__reason {
+  font-size: .78rem;
+}
+
+.playlist-import__reason {
+  border-radius: 999px;
+  padding: .25rem .45rem;
+  background: rgb(0 0 0 / .08);
+  white-space: nowrap;
+}
+
+.playlist-import__long-tracks {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .75rem;
+  margin-top: .75rem;
+  font-size: .8rem;
+}
+
+.playlist-import__long-tracks button,
+.playlist-import__load-more {
+  border: 0;
+  padding: .35rem 0;
+  background: transparent;
+  text-decoration: underline;
+}
+
+.playlist-import__load-more {
+  display: block;
+  margin: .75rem auto 0;
+}
+
+.playlist-import__footer {
+  justify-content: flex-end;
+}
+
+@media (max-width: 640px) {
+  .playlist-import__url-row,
+  .playlist-import__summary,
+  .playlist-import__long-tracks {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .playlist-import__item label {
+    grid-template-columns: auto 4.5rem minmax(0, 1fr);
+  }
+
+  .playlist-import__item img {
+    width: 4.5rem;
+  }
+
+  .playlist-import__reason {
+    grid-column: 2 / -1;
+    justify-self: start;
+  }
+}
+</style>

--- a/app/components/youtube-picker/index.vue
+++ b/app/components/youtube-picker/index.vue
@@ -8,6 +8,7 @@
 <script setup lang="ts">
 import { useYoutubePicker } from './useYoutubePicker'
 import YoutubePickerPreview from './YoutubePickerPreview.vue'
+import YoutubePlaylistImport from './YoutubePlaylistImport.vue'
 import YoutubePickerResultsPane from './YoutubePickerResultsPane.vue'
 import YoutubePickerSearch from './YoutubePickerSearch.vue'
 import {
@@ -153,6 +154,7 @@ onUnmounted(() => {
         @submit="onSearchSubmit"
         @clear="onSearchClear"
       />
+      <YoutubePlaylistImport />
     </div>
 
     <div :class="embedded ? 'flex flex-1 min-h-0 flex-col overflow-hidden' : ''">

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -28,6 +28,23 @@
           />
         </template>
 
+        <template #playlist-header>
+          <label
+            v-if="isNewPlaylist"
+            class="flex items-center"
+          >
+            <span class="sr-only">Playlist title</span>
+            <input
+              v-model="cardTitle"
+              type="text"
+              class="w-48 max-w-[30vw] rounded-maru border-2 border-maru-black bg-maru-white px-2 py-1 font-maru-mono text-sm text-maru-black"
+              placeholder="Playlist title"
+              autocomplete="off"
+              :disabled="isPlaylistLocked"
+            >
+          </label>
+        </template>
+
         <template #playlist-footer>
           <PlaylistPanelFooter />
         </template>
@@ -91,7 +108,11 @@ import AppSplash from '~/components/splash/AppSplash.vue'
 const yoto = useYotoMyo()
 provide(YOTO_MYO_KEY, yoto)
 
-const editor = useMyoEditor()
+const editor = useMyoEditor({
+  onPlaylistCreated: () => {
+    void yoto.refreshAfterCreate()
+  },
+})
 provide(MYO_EDITOR_KEY, editor)
 
 const route = useRoute()
@@ -100,7 +121,13 @@ const router = useRouter()
 const { playEvent } = useUiSound()
 const { shouldShowSplash, splashHoldsGate, splashDebug, markSplashSeen } = useAppSplash()
 
-const { playlist, isPlaylistLocked, selectedCardId, cardTitle } = editor
+const {
+  playlist,
+  isEditing,
+  isNewPlaylist,
+  isPlaylistLocked,
+  cardTitle,
+} = editor
 const { connected, status } = yoto
 
 const myoCountLabel = ref('')
@@ -145,7 +172,8 @@ watch(
 )
 
 const playlistTitle = computed(() => {
-  if (!selectedCardId.value || !cardTitle.value.trim()) return 'Playlist'
+  if (isNewPlaylist.value && !cardTitle.value.trim()) return 'New Playlist'
+  if (!isEditing.value || !cardTitle.value.trim()) return 'Playlist'
   return cardTitle.value.trim()
 })
 
@@ -227,7 +255,7 @@ function onDragEnd(event: DragEndEvent) {
   }
 
   if (sourceData?.type === 'result') {
-    if (!selectedCardId.value) {
+    if (!isEditing.value) {
       playEvent('disabled')
       return
     }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "start": "node .output/server/index.mjs",
-    "test": "node --experimental-strip-types --test shared/**/*.test.ts",
+    "test": "node --experimental-strip-types --test shared/**/*.test.ts server/**/*.test.ts",
     "postinstall": "nuxt prepare",
     "release": "release-it"
   },

--- a/server/api/yoto/content/[cardId]/save.post.ts
+++ b/server/api/yoto/content/[cardId]/save.post.ts
@@ -34,7 +34,7 @@ export default defineEventHandler(async (event) => {
 
   const job = startSaveJob(
     event,
-    cardId,
+    { operation: 'update', cardId },
     body.playlist,
     body.cardTitle?.trim() || 'My Card',
     Array.isArray(body.baselinePlaylist) ? body.baselinePlaylist : [],

--- a/server/api/yoto/content/save.post.ts
+++ b/server/api/yoto/content/save.post.ts
@@ -1,0 +1,43 @@
+import { getStandalonePlaylistValidationError } from '#shared/myo-editor/standalonePlaylist'
+import type { PlaylistTrack } from '#shared/myo-editor/types'
+import { getScopeCookie, hasContentManageScope } from '../../../utils/yoto-auth'
+import { startSaveJob } from '../../../utils/save-jobs'
+import { getYotoAccessToken } from '../../../utils/yoto'
+
+interface CreateSaveRequestBody {
+  playlist: PlaylistTrack[]
+  cardTitle: string
+  /** When true, skip our MYO capacity gates and let Yoto decide. */
+  acknowledgeCapacityRisk?: boolean
+}
+
+export default defineEventHandler(async (event) => {
+  const scope = getScopeCookie(event)
+  if (!hasContentManageScope(scope)) {
+    throw createError({
+      statusCode: 403,
+      statusMessage: 'Reconnect to Yoto to grant playlist edit permission (user:content:manage).',
+    })
+  }
+
+  await getYotoAccessToken(event)
+
+  const body = await readBody<CreateSaveRequestBody>(event)
+  const playlist = Array.isArray(body?.playlist) ? body.playlist : []
+  const cardTitle = body?.cardTitle?.trim() ?? ''
+  const validationError = getStandalonePlaylistValidationError(cardTitle, playlist)
+  if (validationError) {
+    throw createError({ statusCode: 400, statusMessage: validationError })
+  }
+
+  const job = startSaveJob(
+    event,
+    { operation: 'create' },
+    playlist,
+    cardTitle,
+    [],
+    { acknowledgeCapacityRisk: body?.acknowledgeCapacityRisk === true },
+  )
+
+  return { jobId: job.id, status: job.status }
+})

--- a/server/api/youtube/playlist.get.ts
+++ b/server/api/youtube/playlist.get.ts
@@ -1,0 +1,188 @@
+import {
+  isYoutubePlaylistId,
+  type YoutubePlaylistImportResponse,
+} from '#shared/myo-editor/youtubePlaylistImport'
+import { parseYoutubeDurationIso } from '#shared/myo-editor/youtubeDuration'
+import {
+  decodeHtmlEntities,
+  fetchYoutubeApiCached,
+  getYoutubeApiKey,
+  pickThumbnail,
+} from '../../utils/youtube'
+import { fetchYoutubePlaylistPageSources } from '../../utils/youtube-playlist'
+
+interface YoutubePlaylistListItem {
+  id: string
+  snippet?: {
+    title?: string
+    channelTitle?: string
+  }
+  contentDetails?: {
+    itemCount?: number
+  }
+  status?: {
+    privacyStatus?: string
+  }
+}
+
+interface YoutubePlaylistListResponse {
+  items?: YoutubePlaylistListItem[]
+}
+
+interface YoutubePlaylistItem {
+  id: string
+  snippet?: {
+    title?: string
+    channelTitle?: string
+    position?: number
+    thumbnails?: Record<string, { url: string } | undefined>
+    resourceId?: {
+      videoId?: string
+    }
+  }
+  contentDetails?: {
+    videoId?: string
+  }
+}
+
+interface YoutubePlaylistItemsResponse {
+  items?: YoutubePlaylistItem[]
+  nextPageToken?: string
+}
+
+interface YoutubeVideoItem {
+  id: string
+  snippet?: {
+    title?: string
+    channelTitle?: string
+    thumbnails?: Record<string, { url: string } | undefined>
+  }
+  contentDetails?: {
+    duration?: string
+  }
+  status?: {
+    uploadStatus?: string
+    privacyStatus?: string
+  }
+}
+
+interface YoutubeVideosResponse {
+  items?: YoutubeVideoItem[]
+}
+
+export default defineEventHandler(async (event): Promise<YoutubePlaylistImportResponse> => {
+  const query = getQuery(event)
+  const playlistId = String(query.playlistId ?? '').trim()
+  const pageToken = query.pageToken ? String(query.pageToken) : undefined
+
+  if (!isYoutubePlaylistId(playlistId)) {
+    throw createError({
+      statusCode: 400,
+      message: 'A valid YouTube playlist ID is required',
+    })
+  }
+
+  const apiKey = getYoutubeApiKey(event)
+  const [playlistData, itemsData] = await fetchYoutubePlaylistPageSources<
+    YoutubePlaylistListResponse,
+    YoutubePlaylistItemsResponse
+  >(fetchYoutubeApiCached, {
+    playlistId,
+    pageToken,
+    apiKey,
+  })
+  const playlistItem = playlistData?.items?.[0]
+
+  if (!playlistItem) {
+    throw createError({
+      statusCode: 404,
+      message: 'Public YouTube playlist not found',
+    })
+  }
+  if (playlistItem?.status?.privacyStatus !== 'public') {
+    throw createError({
+      statusCode: 400,
+      message: 'Only public YouTube playlists can be imported',
+    })
+  }
+
+  const sourceItems = itemsData.items ?? []
+  const videoIds = [
+    ...new Set(
+      sourceItems
+        .map(item => item.contentDetails?.videoId ?? item.snippet?.resourceId?.videoId)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  ]
+
+  let videosData: YoutubeVideosResponse = {}
+  if (videoIds.length > 0) {
+    const videosParams = new URLSearchParams({
+      part: 'snippet,contentDetails,status',
+      id: videoIds.join(','),
+      key: apiKey,
+    })
+    videosData = await fetchYoutubeApiCached<YoutubeVideosResponse>(
+      `playlist-videos:${[...videoIds].sort().join(',')}`,
+      `https://www.googleapis.com/youtube/v3/videos?${videosParams}`,
+    )
+  }
+
+  const videosById = new Map(
+    (videosData.items ?? []).map(video => [video.id, video]),
+  )
+
+  return {
+    playlist: playlistItem
+      ? {
+          id: playlistItem.id,
+          title: decodeHtmlEntities(playlistItem.snippet?.title ?? 'YouTube playlist'),
+          channelTitle: decodeHtmlEntities(playlistItem.snippet?.channelTitle ?? ''),
+          itemCount: playlistItem.contentDetails?.itemCount,
+        }
+      : undefined,
+    items: sourceItems.map((sourceItem, index) => {
+      const videoId
+        = sourceItem.contentDetails?.videoId
+          ?? sourceItem.snippet?.resourceId?.videoId
+          ?? ''
+      const video = videosById.get(videoId)
+      const duration = video?.contentDetails?.duration
+      const durationSeconds = duration
+        ? parseYoutubeDurationIso(duration) ?? undefined
+        : undefined
+      const uploadStatus = video?.status?.uploadStatus?.toLowerCase()
+      const privacyStatus = video?.status?.privacyStatus?.toLowerCase()
+      const available = Boolean(
+        video
+        && privacyStatus !== 'private'
+        && (!uploadStatus || uploadStatus === 'processed' || uploadStatus === 'uploaded'),
+      )
+
+      return {
+        playlistItemId: sourceItem.id || `${playlistId}:${pageToken ?? 'first'}:${index}`,
+        videoId,
+        position: sourceItem.snippet?.position ?? index,
+        title: decodeHtmlEntities(
+          video?.snippet?.title
+          ?? sourceItem.snippet?.title
+          ?? 'Unavailable video',
+        ),
+        channelTitle: decodeHtmlEntities(
+          video?.snippet?.channelTitle
+          ?? sourceItem.snippet?.channelTitle
+          ?? '',
+        ),
+        thumbnailUrl: pickThumbnail(
+          video?.snippet?.thumbnails
+          ?? sourceItem.snippet?.thumbnails
+          ?? {},
+        ),
+        duration,
+        durationSeconds,
+        available,
+      }
+    }),
+    nextPageToken: itemsData.nextPageToken,
+  }
+})

--- a/server/utils/save-jobs.ts
+++ b/server/utils/save-jobs.ts
@@ -20,12 +20,22 @@ import {
 import { downloadYoutubeAudio } from './youtube-download'
 import { uploadAudioFile } from './yoto-media'
 import { createOrUpdateContent } from './yoto-content'
+import {
+  isUncertainCreatePostError,
+  requireCreatedCardId,
+  UNCERTAIN_CREATE_POST_MESSAGE,
+  withContentCardId,
+} from './yoto-content-contract'
 import { mergeContentMetadata } from './yoto-metadata'
 import { fetchYotoCardDetail } from './yoto-card-detail'
 import { getYotoAccessToken } from './yoto'
 
 /** Process-local only — cleared on every container restart/redeploy. See docs/DEMO.md §4b. */
 const jobs = new Map<string, SaveJobState>()
+
+export type SaveTarget =
+  | { operation: 'create' }
+  | { operation: 'update'; cardId: string }
 
 function createTrackProgress(playlist: PlaylistTrack[]): SaveJobTrackProgress[] {
   return playlist.map((track, index) => ({
@@ -88,7 +98,7 @@ export function getSaveJob(jobId: string): SaveJobState | undefined {
 
 export function startSaveJob(
   event: H3Event,
-  cardId: string,
+  target: SaveTarget,
   playlist: PlaylistTrack[],
   cardTitle: string,
   baselinePlaylist: PlaylistTrack[],
@@ -98,7 +108,8 @@ export function startSaveJob(
   const acknowledgeCapacityRisk = options?.acknowledgeCapacityRisk === true
   const job: SaveJobState = {
     id: jobId,
-    cardId,
+    operation: target.operation,
+    cardId: target.operation === 'update' ? target.cardId : undefined,
     status: 'planning',
     progress: 0,
     operationProgress: 0,
@@ -114,7 +125,7 @@ export function startSaveJob(
         event,
         accessToken,
         jobId,
-        cardId,
+        target,
         playlist,
         cardTitle,
         baselinePlaylist,
@@ -138,7 +149,7 @@ async function runSaveJob(
   event: H3Event,
   accessToken: string,
   jobId: string,
-  cardId: string,
+  target: SaveTarget,
   playlist: PlaylistTrack[],
   cardTitle: string,
   baselinePlaylist: PlaylistTrack[],
@@ -148,9 +159,12 @@ async function runSaveJob(
   if (!job) return
 
   const uploadedByIndex = new Map<number, TranscodedAudioResult>()
+  let createOutcomeUncertain = false
 
   try {
-    const detail = await fetchYotoCardDetail(cardId, accessToken)
+    const detail = target.operation === 'update'
+      ? await fetchYotoCardDetail(target.cardId, accessToken)
+      : undefined
 
     const plan = buildSavePlan(baselinePlaylist, playlist, detail)
     if (plan.errors.length > 0) {
@@ -290,8 +304,8 @@ async function runSaveJob(
       plan.tracks,
       uploadedByIndex,
       {
-        existingMetadataNote: detail.metadataNote,
-        existingContentVersion: detail.contentVersion,
+        existingMetadataNote: detail?.metadataNote,
+        existingContentVersion: detail?.contentVersion,
       },
     )
 
@@ -335,23 +349,45 @@ async function runSaveJob(
       }
     }
 
-    await createOrUpdateContent(accessToken, {
-      cardId,
-      title: cardTitle,
-      content: {
-        version: built.contentVersion,
-        chapters: built.chapters,
-      },
-      metadata: mergeContentMetadata(detail.metadata, {
-        title: cardTitle,
-        note: built.note,
-        media: {
-          duration: built.totalDuration,
-          fileSize: built.totalFileSize,
-          readableFileSize: Math.round((built.totalFileSize / 1024 / 1024) * 10) / 10,
+    let response
+    try {
+      response = await createOrUpdateContent(accessToken, withContentCardId(
+        target.operation,
+        target.operation === 'update' ? target.cardId : undefined,
+        {
+          title: cardTitle,
+          content: {
+            version: built.contentVersion,
+            chapters: built.chapters,
+          },
+          metadata: mergeContentMetadata(detail?.metadata, {
+            title: cardTitle,
+            note: built.note,
+            media: {
+              duration: built.totalDuration,
+              fileSize: built.totalFileSize,
+              readableFileSize: Math.round((built.totalFileSize / 1024 / 1024) * 10) / 10,
+            },
+          }),
         },
-      }),
-    })
+      ))
+    }
+    catch (err: unknown) {
+      if (target.operation === 'create' && isUncertainCreatePostError(err)) {
+        createOutcomeUncertain = true
+        throw createError({
+          statusCode: 502,
+          message: UNCERTAIN_CREATE_POST_MESSAGE,
+        })
+      }
+      throw err
+    }
+
+    if (target.operation === 'create') {
+      createOutcomeUncertain = true
+      updateJob(jobId, { cardId: requireCreatedCardId(response) })
+      createOutcomeUncertain = false
+    }
 
     updateJob(jobId, { status: 'complete', progress: 100, operationProgress: 100 })
   }
@@ -371,7 +407,12 @@ async function runSaveJob(
       }
     }
 
-    updateJob(jobId, { status: 'failed', error: message, progress: 100 })
+    updateJob(jobId, {
+      status: 'failed',
+      error: message,
+      outcomeUncertain: createOutcomeUncertain || undefined,
+      progress: 100,
+    })
   }
 }
 

--- a/server/utils/yoto-content-contract.test.ts
+++ b/server/utils/yoto-content-contract.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  isUncertainCreatePostError,
+  requireCreatedCardId,
+  withContentCardId,
+} from './yoto-content-contract.ts'
+
+describe('Yoto content create contract', () => {
+  it('omits cardId for create and includes it for update', () => {
+    assert.deepEqual(
+      withContentCardId('create', undefined, { title: 'New playlist' }),
+      { title: 'New playlist' },
+    )
+    assert.deepEqual(
+      withContentCardId('update', 'existing-card', { title: 'Existing playlist' }),
+      { title: 'Existing playlist', cardId: 'existing-card' },
+    )
+  })
+
+  it('requires the official card.cardId create response', () => {
+    assert.equal(
+      requireCreatedCardId({ card: { cardId: 'created-card' } }),
+      'created-card',
+    )
+    assert.throws(
+      () => requireCreatedCardId({}),
+      /It may already exist; check My Cards before trying again/,
+    )
+    assert.throws(
+      () => requireCreatedCardId({
+        card: { cardId: 'created-card' },
+        cardId: 'different-card',
+      }),
+      /conflicting card IDs/,
+    )
+  })
+
+  it('treats transport-like final create failures as uncertain', () => {
+    assert.equal(isUncertainCreatePostError(new TypeError('fetch failed')), true)
+    assert.equal(isUncertainCreatePostError({ statusCode: 408 }), true)
+    assert.equal(isUncertainCreatePostError({ statusCode: 502 }), true)
+  })
+
+  it('keeps explicit Yoto rejections retryable', () => {
+    assert.equal(isUncertainCreatePostError({ statusCode: 400 }), false)
+    assert.equal(isUncertainCreatePostError({ statusCode: 401 }), false)
+    assert.equal(isUncertainCreatePostError({ statusCode: 403 }), false)
+    assert.equal(isUncertainCreatePostError({ statusCode: 429 }), false)
+  })
+})

--- a/server/utils/yoto-content-contract.ts
+++ b/server/utils/yoto-content-contract.ts
@@ -1,0 +1,41 @@
+export interface YotoContentResponse {
+  card?: { cardId?: string }
+  cardId?: string
+}
+
+export const UNCERTAIN_CREATE_POST_MESSAGE
+  = 'Could not confirm whether Yoto created this playlist. Check My Cards before trying again.'
+
+export function isUncertainCreatePostError(error: unknown): boolean {
+  const statusCode = (error as { statusCode?: number }).statusCode
+  return statusCode === undefined || statusCode === 408 || statusCode >= 500
+}
+
+export function withContentCardId<T extends object>(
+  operation: 'create' | 'update',
+  cardId: string | undefined,
+  body: T,
+): T & { cardId?: string } {
+  if (operation === 'create') return body
+
+  const existingCardId = cardId?.trim()
+  if (!existingCardId) throw new Error('Existing card ID is required for an update.')
+  return { ...body, cardId: existingCardId }
+}
+
+export function requireCreatedCardId(response: YotoContentResponse): string {
+  const nestedCardId = response.card?.cardId?.trim()
+  const topLevelCardId = response.cardId?.trim()
+
+  if (!nestedCardId) {
+    throw new Error(
+      'Yoto did not return card.cardId after creating the playlist. It may already exist; check My Cards before trying again.',
+    )
+  }
+  if (topLevelCardId && topLevelCardId !== nestedCardId) {
+    throw new Error(
+      'Yoto returned conflicting card IDs after creating the playlist. Check My Cards before trying again.',
+    )
+  }
+  return nestedCardId
+}

--- a/server/utils/yoto-content.ts
+++ b/server/utils/yoto-content.ts
@@ -1,6 +1,7 @@
 import type { YotoTrackPayload } from '#shared/myo-editor/types'
 import type { YotoCardMetadata } from '#shared/myo-editor/types'
 import { fetchYotoApi } from './yoto'
+import type { YotoContentResponse } from './yoto-content-contract'
 
 export interface YotoContentChapter {
   key: string
@@ -30,16 +31,11 @@ export interface CreateOrUpdateContentBody {
   }
 }
 
-interface CreateOrUpdateContentResponse {
-  card?: { cardId?: string }
-  cardId?: string
-}
-
 export async function createOrUpdateContent(
   accessToken: string,
   body: CreateOrUpdateContentBody,
-): Promise<CreateOrUpdateContentResponse> {
-  return fetchYotoApi<CreateOrUpdateContentResponse>('/content', accessToken, {
+): Promise<YotoContentResponse> {
+  return fetchYotoApi<YotoContentResponse>('/content', accessToken, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body,

--- a/server/utils/youtube-playlist.test.ts
+++ b/server/utils/youtube-playlist.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { fetchYoutubePlaylistPageSources } from './youtube-playlist.ts'
+
+describe('fetchYoutubePlaylistPageSources', () => {
+  it('retains public-playlist metadata validation for paginated requests', async () => {
+    const calls: Array<{ cacheKey: string, url: string }> = []
+    const playlistResponse = { items: [{ id: 'PL1234567890' }] }
+    const itemsResponse = { items: [], nextPageToken: 'next-token' }
+
+    const fetchCached = async <T>(cacheKey: string, url: string): Promise<T> => {
+      calls.push({ cacheKey, url })
+      return (cacheKey.startsWith('playlist-items:')
+        ? itemsResponse
+        : playlistResponse) as T
+    }
+
+    const [playlist, items] = await fetchYoutubePlaylistPageSources<
+      typeof playlistResponse,
+      typeof itemsResponse
+    >(fetchCached, {
+      playlistId: 'PL1234567890',
+      pageToken: 'page-two-token',
+      apiKey: 'test-key',
+    })
+
+    assert.equal(playlist, playlistResponse)
+    assert.equal(items, itemsResponse)
+    assert.equal(calls.length, 2)
+    assert.equal(calls[0]?.cacheKey, 'playlist:PL1234567890')
+    assert.match(calls[0]?.url ?? '', /\/youtube\/v3\/playlists\?/)
+    assert.equal(calls[1]?.cacheKey, 'playlist-items:PL1234567890:page-two-token')
+    assert.match(calls[1]?.url ?? '', /pageToken=page-two-token/)
+  })
+})

--- a/server/utils/youtube-playlist.ts
+++ b/server/utils/youtube-playlist.ts
@@ -1,0 +1,41 @@
+export interface YoutubePlaylistPageSourceOptions {
+  playlistId: string
+  pageToken?: string
+  apiKey: string
+}
+
+type YoutubeApiFetcher = <T>(cacheKey: string, url: string) => Promise<T>
+
+/**
+ * Fetch playlist metadata on every page so public-only validation cannot be
+ * bypassed or accidentally skipped. The shared API cache avoids repeat quota
+ * cost while the user pages through a playlist.
+ */
+export async function fetchYoutubePlaylistPageSources<TPlaylist, TItems>(
+  fetchCached: YoutubeApiFetcher,
+  options: YoutubePlaylistPageSourceOptions,
+): Promise<[TPlaylist, TItems]> {
+  const playlistParams = new URLSearchParams({
+    part: 'snippet,contentDetails,status',
+    id: options.playlistId,
+    key: options.apiKey,
+  })
+  const itemsParams = new URLSearchParams({
+    part: 'snippet,contentDetails',
+    playlistId: options.playlistId,
+    maxResults: '50',
+    key: options.apiKey,
+  })
+  if (options.pageToken) itemsParams.set('pageToken', options.pageToken)
+
+  return await Promise.all([
+    fetchCached<TPlaylist>(
+      `playlist:${options.playlistId}`,
+      `https://www.googleapis.com/youtube/v3/playlists?${playlistParams}`,
+    ),
+    fetchCached<TItems>(
+      `playlist-items:${options.playlistId}:${options.pageToken ?? ''}`,
+      `https://www.googleapis.com/youtube/v3/playlistItems?${itemsParams}`,
+    ),
+  ])
+}

--- a/shared/myo-editor/buildSavePlan.ts
+++ b/shared/myo-editor/buildSavePlan.ts
@@ -5,11 +5,13 @@ import { toYotoTrackReuseSnapshot } from './yotoTrackPayload'
 
 function reuseSnapshotForTrack(
   track: PlaylistTrack,
-  detail: YotoCardDetail,
+  detail?: YotoCardDetail,
 ): YotoTrackReuseSnapshot | null {
   if (track.yotoReuse?.trackUrl?.startsWith('yoto:#')) {
     return track.yotoReuse
   }
+
+  if (!detail) return null
 
   const original = findOriginalTrack(detail, track)
   if (original && isYotoHostedTrack(original)) {
@@ -22,7 +24,7 @@ function reuseSnapshotForTrack(
 function classifyTrack(
   track: PlaylistTrack,
   index: number,
-  detail: YotoCardDetail,
+  detail: YotoCardDetail | undefined,
   baselineIds: Set<string>,
 ): SaveTrackAction {
   if (track.source === 'unknown') {
@@ -99,11 +101,11 @@ function classifyTrack(
 export function buildSavePlan(
   baselinePlaylist: PlaylistTrack[],
   playlist: PlaylistTrack[],
-  detail: YotoCardDetail,
+  detail?: YotoCardDetail,
 ): SavePlan {
   const errors: string[] = []
 
-  if (detail.feedUrl?.trim()) {
+  if (detail?.feedUrl?.trim()) {
     errors.push('Podcast cards cannot be edited yet.')
     return { tracks: [], errors }
   }

--- a/shared/myo-editor/standalonePlaylist.test.ts
+++ b/shared/myo-editor/standalonePlaylist.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import type { PlaylistTrack } from './types.ts'
+import {
+  classifyCreateStartFailure,
+  getStandalonePlaylistValidationError,
+  isPlaylistEditorActive,
+  notifyConfirmedPlaylistCreated,
+  resolveClientSaveTarget,
+  resolveSavedCardId,
+  shouldWarnBeforeUnload,
+} from './standalonePlaylist.ts'
+
+function youtubeTrack(id = 'video-1'): PlaylistTrack {
+  return {
+    id,
+    title: 'Track',
+    subtitle: 'Channel',
+    thumbnailUrl: '',
+    source: 'app-youtube',
+    youtubeId: id,
+  }
+}
+
+describe('standalone playlist drafts', () => {
+  it('keeps a local draft editable without a remote card ID', () => {
+    assert.equal(isPlaylistEditorActive(null, true), true)
+    assert.equal(isPlaylistEditorActive(null, false), false)
+    assert.equal(isPlaylistEditorActive('existing-card', false), true)
+  })
+
+  it('resolves create and update from one discriminated client target', () => {
+    assert.deepEqual(
+      resolveClientSaveTarget({ operation: 'create' }),
+      {
+        operation: 'create',
+        saveKey: 'new-playlist-draft',
+        endpoint: '/api/yoto/content/save',
+      },
+    )
+    assert.deepEqual(
+      resolveClientSaveTarget({ operation: 'update', cardId: 'existing-card' }),
+      {
+        operation: 'update',
+        saveKey: 'existing-card',
+        cardId: 'existing-card',
+        endpoint: '/api/yoto/content/existing-card/save',
+      },
+    )
+    assert.throws(
+      () => resolveClientSaveTarget({ operation: 'update', cardId: '  ' }),
+      /Existing card ID is required/,
+    )
+  })
+
+  it('requires a title and supported YouTube tracks before create', () => {
+    assert.equal(
+      getStandalonePlaylistValidationError('   ', [youtubeTrack()]),
+      'Give this playlist a title before creating it.',
+    )
+    assert.equal(
+      getStandalonePlaylistValidationError('Bedtime', []),
+      'Add at least one YouTube track before creating this playlist.',
+    )
+    assert.equal(getStandalonePlaylistValidationError('Bedtime', [youtubeTrack()]), null)
+  })
+
+  it('rejects non-YouTube tracks from a new playlist', () => {
+    assert.equal(
+      getStandalonePlaylistValidationError('Bedtime', [{
+        ...youtubeTrack(),
+        source: 'yoto-upload',
+      }]),
+      'New playlists can only include supported YouTube tracks.',
+    )
+  })
+
+  it('promotes a create using the returned ID and leaves update identity unchanged', () => {
+    assert.equal(resolveSavedCardId('create', null, 'created-card'), 'created-card')
+    assert.equal(resolveSavedCardId('update', 'existing-card', 'ignored-card'), 'existing-card')
+    assert.throws(
+      () => resolveSavedCardId('create', null),
+      /Check My Cards before trying again/,
+    )
+  })
+
+  it('notifies only after a confirmed create', () => {
+    const notified: string[] = []
+    const notify = (cardId: string) => notified.push(cardId)
+
+    notifyConfirmedPlaylistCreated('update', 'existing-card', notify)
+    notifyConfirmedPlaylistCreated('create', 'created-card', notify)
+
+    assert.deepEqual(notified, ['created-card'])
+  })
+
+  it('keeps confirmed pre-job create failures retryable', () => {
+    assert.deepEqual(
+      classifyCreateStartFailure({
+        statusCode: 400,
+        data: { statusMessage: 'Give this playlist a title.' },
+      }),
+      {
+        message: 'Give this playlist a title.',
+        outcomeUncertain: false,
+      },
+    )
+    assert.equal(
+      classifyCreateStartFailure({
+        statusCode: 403,
+        statusMessage: 'Reconnect to Yoto.',
+      }).outcomeUncertain,
+      false,
+    )
+  })
+
+  it('blocks another create when the startup response is lost or ambiguous', () => {
+    const failure = classifyCreateStartFailure(new TypeError('Failed to fetch'))
+
+    assert.equal(failure.outcomeUncertain, true)
+    assert.match(failure.message, /Check My Cards before trying again/)
+  })
+
+  it('warns before unload only for dirty, unlocked editor state', () => {
+    assert.equal(shouldWarnBeforeUnload(true, false), true)
+    assert.equal(shouldWarnBeforeUnload(false, false), false)
+    assert.equal(shouldWarnBeforeUnload(true, true), false)
+  })
+})

--- a/shared/myo-editor/standalonePlaylist.ts
+++ b/shared/myo-editor/standalonePlaylist.ts
@@ -1,0 +1,138 @@
+import type { PlaylistTrack, SaveOperation } from './types'
+
+export const NEW_PLAYLIST_SAVE_KEY = 'new-playlist-draft'
+export const UNCERTAIN_CREATE_START_MESSAGE
+  = 'Could not confirm whether Louis started creating this playlist. Check My Cards before trying again.'
+
+export type ClientSaveTarget =
+  | { operation: 'create' }
+  | { operation: 'update'; cardId: string }
+
+export type ClientSaveIdentity =
+  | {
+    operation: 'create'
+    saveKey: typeof NEW_PLAYLIST_SAVE_KEY
+    endpoint: '/api/yoto/content/save'
+  }
+  | {
+    operation: 'update'
+    saveKey: string
+    cardId: string
+    endpoint: string
+  }
+
+interface FetchErrorLike {
+  statusCode?: number
+  statusMessage?: string
+  data?: { statusMessage?: string }
+  message?: string
+}
+
+export function isPlaylistEditorActive(
+  selectedCardId: string | null,
+  isNewPlaylist: boolean,
+): boolean {
+  return isNewPlaylist || Boolean(selectedCardId)
+}
+
+export function resolveClientSaveTarget(target: ClientSaveTarget): ClientSaveIdentity {
+  if (target.operation === 'create') {
+    return {
+      operation: 'create',
+      saveKey: NEW_PLAYLIST_SAVE_KEY,
+      endpoint: '/api/yoto/content/save',
+    }
+  }
+
+  const cardId = target.cardId.trim()
+  if (!cardId) throw new Error('Existing card ID is required for an update.')
+
+  return {
+    operation: 'update',
+    saveKey: cardId,
+    cardId,
+    endpoint: `/api/yoto/content/${cardId}/save`,
+  }
+}
+
+export function isSupportedYoutubeTrack(track: PlaylistTrack): boolean {
+  if (!track || typeof track !== 'object') return false
+  if (track.source !== 'app-youtube' && track.source !== 'youtube-url') return false
+  const youtubeId = typeof track.youtubeId === 'string' ? track.youtubeId.trim() : ''
+  const appYoutubeId = track.source === 'app-youtube' && typeof track.id === 'string'
+    ? track.id.trim()
+    : ''
+  return Boolean(youtubeId || appYoutubeId)
+}
+
+export function getStandalonePlaylistValidationError(
+  title: string,
+  playlist: PlaylistTrack[],
+): string | null {
+  if (!title.trim()) {
+    return 'Give this playlist a title before creating it.'
+  }
+  if (playlist.length === 0) {
+    return 'Add at least one YouTube track before creating this playlist.'
+  }
+  if (playlist.some(track => !isSupportedYoutubeTrack(track))) {
+    return 'New playlists can only include supported YouTube tracks.'
+  }
+  return null
+}
+
+export function resolveSavedCardId(
+  operation: SaveOperation,
+  existingCardId: string | null,
+  returnedCardId?: string,
+): string {
+  if (operation === 'update') {
+    const cardId = existingCardId?.trim()
+    if (!cardId) throw new Error('Existing card ID is required for an update.')
+    return cardId
+  }
+
+  const cardId = returnedCardId?.trim()
+  if (!cardId) {
+    throw new Error(
+      'Yoto did not return an ID for the created playlist. Check My Cards before trying again.',
+    )
+  }
+  return cardId
+}
+
+export function notifyConfirmedPlaylistCreated(
+  operation: SaveOperation,
+  cardId: string,
+  notify?: (cardId: string) => void,
+): void {
+  if (operation === 'create') notify?.(cardId)
+}
+
+export function classifyCreateStartFailure(error: unknown): {
+  message: string
+  outcomeUncertain: boolean
+} {
+  const fetchError = error as FetchErrorLike
+  const message = fetchError.data?.statusMessage
+    ?? fetchError.statusMessage
+    ?? fetchError.message
+    ?? 'Failed to create playlist'
+
+  if (
+    fetchError.statusCode === 400
+    || fetchError.statusCode === 401
+    || fetchError.statusCode === 403
+  ) {
+    return { message, outcomeUncertain: false }
+  }
+
+  return {
+    message: UNCERTAIN_CREATE_START_MESSAGE,
+    outcomeUncertain: true,
+  }
+}
+
+export function shouldWarnBeforeUnload(isDirty: boolean, isLocked: boolean): boolean {
+  return isDirty && !isLocked
+}

--- a/shared/myo-editor/types.ts
+++ b/shared/myo-editor/types.ts
@@ -120,6 +120,8 @@ export interface SavePlan {
   errors: string[]
 }
 
+export type SaveOperation = 'create' | 'update'
+
 export type SaveJobPhase =
   | 'planning'
   | 'downloading'
@@ -146,7 +148,11 @@ export interface SaveJobTrackProgress {
 
 export interface SaveJobState {
   id: string
-  cardId: string
+  operation: SaveOperation
+  /** Existing card for updates; populated with Yoto's returned ID after a create. */
+  cardId?: string
+  /** A create may have reached Yoto even though Louis could not confirm the result. */
+  outcomeUncertain?: boolean
   status: SaveJobPhase
   /** Monotonic 0–100 progress for the entire save job. */
   progress: number

--- a/shared/myo-editor/youtubePlaylistImport.test.ts
+++ b/shared/myo-editor/youtubePlaylistImport.test.ts
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import type { PlaylistTrack } from './types.ts'
+import {
+  evaluateYoutubePlaylistImport,
+  parseYoutubePlaylistUrl,
+  preselectYoutubePlaylistImport,
+  type YoutubePlaylistImportItem,
+} from './youtubePlaylistImport.ts'
+import {
+  YOTO_MYO_MAX_CARD_SECONDS,
+  YOTO_MYO_MAX_TRACK_SECONDS,
+  YOTO_MYO_MAX_TRACKS,
+} from './yotoMyoLimits.ts'
+
+function item(
+  id: string,
+  partial: Partial<YoutubePlaylistImportItem> = {},
+): YoutubePlaylistImportItem {
+  return {
+    playlistItemId: `item-${id}`,
+    videoId: id,
+    position: 0,
+    title: id,
+    channelTitle: 'Channel',
+    thumbnailUrl: '',
+    durationSeconds: 60,
+    available: true,
+    ...partial,
+  }
+}
+
+function track(
+  id: string,
+  partial: Partial<PlaylistTrack> = {},
+): PlaylistTrack {
+  return {
+    id,
+    title: id,
+    subtitle: '',
+    thumbnailUrl: '',
+    source: 'app-youtube',
+    youtubeId: id,
+    duration: 60,
+    ...partial,
+  }
+}
+
+describe('parseYoutubePlaylistUrl', () => {
+  it('accepts supported HTTPS YouTube hosts', () => {
+    assert.equal(
+      parseYoutubePlaylistUrl('https://www.youtube.com/playlist?list=PL1234567890'),
+      'PL1234567890',
+    )
+    assert.equal(
+      parseYoutubePlaylistUrl('https://music.youtube.com/watch?v=abc&list=PLabcdefghij'),
+      'PLabcdefghij',
+    )
+    assert.equal(
+      parseYoutubePlaylistUrl('https://youtu.be/abc?list=PLabcdefghij'),
+      'PLabcdefghij',
+    )
+  })
+
+  it('rejects ambiguous, spoofed, and non-HTTPS URLs', () => {
+    assert.equal(parseYoutubePlaylistUrl('PL1234567890'), null)
+    assert.equal(parseYoutubePlaylistUrl('http://youtube.com/playlist?list=PL1234567890'), null)
+    assert.equal(parseYoutubePlaylistUrl('https://youtube.com.example/playlist?list=PL1234567890'), null)
+    assert.equal(
+      parseYoutubePlaylistUrl('https://youtube.com/playlist?list=PL1234567890&list=PLabcdefghij'),
+      null,
+    )
+  })
+})
+
+describe('YouTube playlist import selection', () => {
+  it('preselects valid unique items in source order', () => {
+    const plan = preselectYoutubePlaylistImport(
+      [
+        item('one'),
+        item('two'),
+        item('one', { playlistItemId: 'item-one-again' }),
+      ],
+      [],
+      false,
+    )
+
+    assert.deepEqual([...plan.selectedKeys], ['item-one', 'item-two'])
+    assert.equal(plan.items[2]?.blockReason, 'duplicate-source')
+  })
+
+  it('blocks existing, unavailable, missing-duration, and long tracks', () => {
+    const plan = preselectYoutubePlaylistImport(
+      [
+        item('existing'),
+        item('gone', { available: false }),
+        item('unknown', { durationSeconds: undefined }),
+        item('long', { durationSeconds: YOTO_MYO_MAX_TRACK_SECONDS + 1 }),
+      ],
+      [track('existing')],
+      false,
+    )
+
+    assert.deepEqual(
+      plan.items.map(entry => entry.blockReason),
+      ['duplicate-existing', 'unavailable', 'missing-duration', 'over-track-duration'],
+    )
+    assert.equal(plan.selectedCount, 0)
+  })
+
+  it('allows long tracks when enabled', () => {
+    const long = item('long', { durationSeconds: YOTO_MYO_MAX_TRACK_SECONDS + 1 })
+    const plan = preselectYoutubePlaylistImport([long], [], true)
+    assert.deepEqual([...plan.selectedKeys], [long.playlistItemId])
+  })
+
+  it('allows exact track and duration capacity', () => {
+    const existing = Array.from({ length: YOTO_MYO_MAX_TRACKS - 1 }, (_, index) =>
+      track(`existing-${index}`, { duration: 1 }),
+    )
+    const remainingDuration
+      = YOTO_MYO_MAX_CARD_SECONDS - (YOTO_MYO_MAX_TRACKS - 1)
+    const candidate = item('last', { durationSeconds: remainingDuration })
+    const plan = preselectYoutubePlaylistImport([candidate], existing, true)
+
+    assert.equal(plan.selectedCount, 1)
+  })
+
+  it('keeps earlier requested selections when capacity is exceeded', () => {
+    const existing = Array.from({ length: YOTO_MYO_MAX_TRACKS - 1 }, (_, index) =>
+      track(`existing-${index}`),
+    )
+    const first = item('first')
+    const second = item('second')
+    const requested = new Set([first.playlistItemId, second.playlistItemId])
+    const plan = evaluateYoutubePlaylistImport([first, second], existing, requested, false)
+
+    assert.deepEqual([...plan.selectedKeys], [first.playlistItemId])
+    assert.equal(plan.items[1]?.blockReason, 'track-capacity')
+  })
+})

--- a/shared/myo-editor/youtubePlaylistImport.ts
+++ b/shared/myo-editor/youtubePlaylistImport.ts
@@ -1,0 +1,214 @@
+import type { PlaylistTrack } from './types.ts'
+import {
+  YOTO_MYO_MAX_CARD_SECONDS,
+  YOTO_MYO_MAX_TRACK_SECONDS,
+  YOTO_MYO_MAX_TRACKS,
+} from './yotoMyoLimits.ts'
+
+const YOUTUBE_PLAYLIST_HOSTS = new Set([
+  'youtube.com',
+  'www.youtube.com',
+  'm.youtube.com',
+  'music.youtube.com',
+  'youtu.be',
+])
+
+const YOUTUBE_PLAYLIST_ID = /^[A-Za-z0-9_-]{10,100}$/
+
+export interface YoutubePlaylistSummary {
+  id: string
+  title: string
+  channelTitle: string
+  itemCount?: number
+}
+
+export interface YoutubePlaylistImportItem {
+  playlistItemId: string
+  videoId: string
+  position: number
+  title: string
+  channelTitle: string
+  thumbnailUrl: string
+  duration?: string
+  durationSeconds?: number
+  available: boolean
+}
+
+export interface YoutubePlaylistImportResponse {
+  playlist?: YoutubePlaylistSummary
+  items: YoutubePlaylistImportItem[]
+  nextPageToken?: string
+}
+
+export type YoutubePlaylistImportBlockReason =
+  | 'unavailable'
+  | 'missing-duration'
+  | 'over-track-duration'
+  | 'duplicate-existing'
+  | 'duplicate-source'
+  | 'track-capacity'
+  | 'duration-capacity'
+
+export interface YoutubePlaylistImportEvaluation {
+  items: Array<{
+    item: YoutubePlaylistImportItem
+    selected: boolean
+    blockReason?: YoutubePlaylistImportBlockReason
+  }>
+  selectedKeys: Set<string>
+  selectedCount: number
+  selectedDurationSeconds: number
+}
+
+export function isYoutubePlaylistId(value: string): boolean {
+  return YOUTUBE_PLAYLIST_ID.test(value)
+}
+
+export function parseYoutubePlaylistUrl(value: string): string | null {
+  let url: URL
+  try {
+    url = new URL(value.trim())
+  }
+  catch {
+    return null
+  }
+
+  if (url.protocol !== 'https:' || !YOUTUBE_PLAYLIST_HOSTS.has(url.hostname.toLowerCase())) {
+    return null
+  }
+
+  const values = url.searchParams.getAll('list')
+  if (values.length !== 1) return null
+
+  const playlistId = values[0]?.trim() ?? ''
+  return isYoutubePlaylistId(playlistId) ? playlistId : null
+}
+
+function trackDurationSeconds(track: PlaylistTrack): number | undefined {
+  if (typeof track.duration === 'number' && Number.isFinite(track.duration) && track.duration > 0) {
+    return track.duration
+  }
+  const duration = track.yotoReuse?.duration
+  if (typeof duration === 'number' && Number.isFinite(duration) && duration > 0) {
+    return duration
+  }
+  return undefined
+}
+
+function baseBlockReason(
+  item: YoutubePlaylistImportItem,
+  existingYoutubeIds: Set<string>,
+  isLaterSourceDuplicate: boolean,
+  allowLongTracks: boolean,
+): YoutubePlaylistImportBlockReason | undefined {
+  if (!item.available) return 'unavailable'
+  if (
+    typeof item.durationSeconds !== 'number'
+    || !Number.isFinite(item.durationSeconds)
+    || item.durationSeconds <= 0
+  ) {
+    return 'missing-duration'
+  }
+  if (!allowLongTracks && item.durationSeconds > YOTO_MYO_MAX_TRACK_SECONDS) {
+    return 'over-track-duration'
+  }
+  if (existingYoutubeIds.has(item.videoId)) return 'duplicate-existing'
+  if (isLaterSourceDuplicate) return 'duplicate-source'
+  return undefined
+}
+
+/**
+ * Evaluates a requested import selection in source order. If the request is
+ * over capacity, earlier playlist entries win and later entries are disabled.
+ */
+export function evaluateYoutubePlaylistImport(
+  items: YoutubePlaylistImportItem[],
+  existingPlaylist: PlaylistTrack[],
+  requestedSelectedKeys: ReadonlySet<string>,
+  allowLongTracks: boolean,
+): YoutubePlaylistImportEvaluation {
+  const existingYoutubeIds = new Set(
+    existingPlaylist
+      .map(track => track.youtubeId)
+      .filter((id): id is string => Boolean(id)),
+  )
+  const firstSourceItemByVideoId = new Map<string, string>()
+  for (const item of items) {
+    if (!firstSourceItemByVideoId.has(item.videoId)) {
+      firstSourceItemByVideoId.set(item.videoId, item.playlistItemId)
+    }
+  }
+
+  let trackCount = existingPlaylist.length
+  let durationSeconds = existingPlaylist.reduce(
+    (sum, track) => sum + (trackDurationSeconds(track) ?? 0),
+    0,
+  )
+  const selectedKeys = new Set<string>()
+  const result: YoutubePlaylistImportEvaluation['items'] = []
+
+  for (const item of items) {
+    const isLaterDuplicate
+      = firstSourceItemByVideoId.get(item.videoId) !== item.playlistItemId
+    const baseReason = baseBlockReason(
+      item,
+      existingYoutubeIds,
+      isLaterDuplicate,
+      allowLongTracks,
+    )
+
+    if (baseReason) {
+      result.push({ item, selected: false, blockReason: baseReason })
+      continue
+    }
+
+    const duration = item.durationSeconds!
+    const overTrackCapacity = trackCount + 1 > YOTO_MYO_MAX_TRACKS
+    const overDurationCapacity = durationSeconds + duration > YOTO_MYO_MAX_CARD_SECONDS
+    const capacityReason: YoutubePlaylistImportBlockReason | undefined
+      = overTrackCapacity
+        ? 'track-capacity'
+        : overDurationCapacity
+          ? 'duration-capacity'
+          : undefined
+
+    if (requestedSelectedKeys.has(item.playlistItemId) && !capacityReason) {
+      selectedKeys.add(item.playlistItemId)
+      trackCount += 1
+      durationSeconds += duration
+      result.push({ item, selected: true })
+      continue
+    }
+
+    result.push({
+      item,
+      selected: false,
+      blockReason: capacityReason,
+    })
+  }
+
+  const existingDurationSeconds = existingPlaylist.reduce(
+    (sum, track) => sum + (trackDurationSeconds(track) ?? 0),
+    0,
+  )
+
+  return {
+    items: result,
+    selectedKeys,
+    selectedCount: selectedKeys.size,
+    selectedDurationSeconds: durationSeconds - existingDurationSeconds,
+  }
+}
+
+export function preselectYoutubePlaylistImport(
+  items: YoutubePlaylistImportItem[],
+  existingPlaylist: PlaylistTrack[],
+  allowLongTracks: boolean,
+): YoutubePlaylistImportEvaluation {
+  return evaluateYoutubePlaylistImport(
+    items,
+    existingPlaylist,
+    new Set(items.map(item => item.playlistItemId)),
+    allowLongTracks,
+  )
+}

--- a/shared/yoto/refreshPolicy.test.ts
+++ b/shared/yoto/refreshPolicy.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { shouldPreserveAuxiliaryRefreshState } from './refreshPolicy.ts'
+
+describe('auxiliary Yoto refresh failure policy', () => {
+  it('preserves a connected editor after a transient post-create refresh failure', () => {
+    assert.equal(
+      shouldPreserveAuxiliaryRefreshState(true, true, 502),
+      true,
+    )
+    assert.equal(
+      shouldPreserveAuxiliaryRefreshState(true, true),
+      true,
+    )
+  })
+
+  it('does not preserve confirmed authentication or authorization loss', () => {
+    assert.equal(
+      shouldPreserveAuxiliaryRefreshState(true, true, 401),
+      false,
+    )
+    assert.equal(
+      shouldPreserveAuxiliaryRefreshState(true, true, 403),
+      false,
+    )
+  })
+
+  it('leaves normal refresh failure behavior unchanged', () => {
+    assert.equal(
+      shouldPreserveAuxiliaryRefreshState(false, true, 502),
+      false,
+    )
+  })
+})

--- a/shared/yoto/refreshPolicy.ts
+++ b/shared/yoto/refreshPolicy.ts
@@ -1,0 +1,12 @@
+export function shouldPreserveAuxiliaryRefreshState(
+  auxiliary: boolean,
+  wasConnected: boolean,
+  statusCode?: number,
+): boolean {
+  const transientFailure = statusCode === undefined
+    || statusCode === 408
+    || statusCode === 429
+    || statusCode >= 500
+
+  return auxiliary && wasConnected && transientFailure
+}


### PR DESCRIPTION
## Summary

- Import public YouTube playlists through a review-before-append workflow.
- Create new Yoto playlists from local drafts without requiring an existing card.
- Preserve explicit save confirmation, MYO capacity checks, and safe handling of uncertain create outcomes.
- Keep the two independently reviewable features as separate logical commits.

## Candidate history

1. `feat: import public YouTube playlists`
2. `feat: create standalone Yoto playlists`

## Validation

- 88 tests passed across 22 suites
- Production build passed
- `git diff --check` passed
- Candidate application tree matches fork `main` except for the intentionally fork-only `AGENTS.md`
- Previous authenticated browser QA covered playlist import and standalone Yoto creation
