### PR TITLE
Electron desktop spike (Phase 0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,18 @@ NOTES.md
 # Demo / self-host data
 data/
 
+# Deno Desktop local spike artifacts (may embed secrets if built with --env-file)
+yoto-cards.app/
+*.app/
+.deno_desktop_entry-*.ts
+yoto-cards.dylib
+
+# Electron desktop spike / packaging outputs
+desktop/out/
+desktop/dist/
+out/
+release/
+
 # Editor / agent tooling
 .cursor/
 .agents/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ How we cut releases: [docs/RELEASE.md](docs/RELEASE.md).
 ## [Unreleased]
 
 ### Added
+- Electron desktop spike (`npm run desktop:spike`): spawns Nitro on `127.0.0.1:4010` in a BrowserWindow — maintainer checkout only; see [docs/DESKTOP.md](docs/DESKTOP.md) and ship checklist [docs/DESKTOP_SHIP.md](docs/DESKTOP_SHIP.md).
 - Phone editor IA below 600px: Search / Library tabs, nested card detail, Add-to-card drawer, Menu tray, toasts, and denser YouTube results (desktop/tablet two-column layout unchanged at `sm+`).
 - Mobile Menu update affordances: Bell + light pink when a save is pending; IndexPointingUp + left-to-right pink progress fill while updating.
 - How-to empty state and How To modal with beat art; Search Clear after submit; phone-friendly over-limit / long-track controls.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Self-hosted **Nuxt** server app. Yoto OAuth token exchange and YouTube audio dow
 
 https://github.com/user-attachments/assets/6083e578-a0ba-4047-8d44-d2c4efad511d
 
-[Self-host](#self-host) · [Native development](#native-development) · [Contributing](CONTRIBUTING.md) · [Releases](docs/RELEASE.md)
+[Self-host](#self-host) · [Native development](#native-development) · [Contributing](CONTRIBUTING.md) · [Releases](docs/RELEASE.md) · [Desktop](docs/DESKTOP.md)
 
 **Personal use only.** You are responsible for complying with [YouTube’s Terms of Service](https://www.youtube.com/t/terms) and applicable law when downloading audio.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,9 +52,11 @@ Install / “Add to Home Screen” affordance in the phone overflow menu (uses t
 
 Optional per-result toggle to expand YouTube chapters into separate playlist tracks. Must compose cleanly with auto ~1-hour long-track splitting.
 
-### Desktop app wrapper (Electron or Tauri)
+### Desktop app wrapper (Electron)
 
 Package Louis as a cross-OS executable so less technical users can run it without Docker/GitHub CLI — consumer-friendly install alongside the one-click hosting work.
+
+**Direction:** Electron shell around the existing Nitro `.output` (spawn Node server → `BrowserWindow`). Deno Desktop was spiked successfully but dropped for dual-runtime risk. See [docs/DESKTOP.md](docs/DESKTOP.md). Ship checklist (merge → Release Assets + GHCR): [docs/DESKTOP_SHIP.md](docs/DESKTOP_SHIP.md).
 
 ### Audio trim
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,0 +1,25 @@
+# Desktop spike (Electron)
+
+Thin Electron host for Louis. Spawns production Nitro from `../.output/server/index.mjs` on `127.0.0.1:4010`.
+
+- `main.mjs` — spawn Nitro, health-wait, `BrowserWindow`, clean quit
+- `preload.cjs` — contextIsolation stub (no APIs exposed yet)
+
+```bash
+npm run build
+npm run desktop:spike
+```
+
+## Spike-only limits (Phase 0)
+
+Not a shippable installer yet. See [DESKTOP_SHIP.md](../docs/DESKTOP_SHIP.md) for the path to Release Assets.
+
+| Area | Spike behavior |
+|------|----------------|
+| yt-dlp / ffmpeg | System `PATH` (e.g. Homebrew) — not bundled |
+| Secrets | Loads repo-root `.env` into the Electron process at runtime — do not distribute that |
+| Layout | Expects a git checkout with `.output/` from `npm run build` |
+| Port | Fixed `127.0.0.1:4010` (document Yoto redirect when testing OAuth) |
+| Packaging | No electron-builder / DMG / NSIS |
+
+Ship checklist: [DESKTOP_SHIP.md](../docs/DESKTOP_SHIP.md). Overview: [DESKTOP.md](../docs/DESKTOP.md).

--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -1,0 +1,182 @@
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawn } from 'node:child_process'
+import fs from 'node:fs'
+import { createInterface } from 'node:readline'
+
+const require = createRequire(import.meta.url)
+const { app, BrowserWindow } = require('electron')
+
+app.setName('Louis')
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(__dirname, '..')
+const nitroEntry = path.join(repoRoot, '.output', 'server', 'index.mjs')
+
+const HOST = '127.0.0.1'
+const PORT = 4010
+const BASE_URL = `http://${HOST}:${PORT}`
+const HEALTH_URL = `${BASE_URL}/api/health`
+
+/** @type {import('node:child_process').ChildProcess | null} */
+let nitroChild = null
+/** @type {import('electron').BrowserWindow | null} */
+let mainWindow = null
+let quitting = false
+
+function loadDotEnv() {
+  const envPath = path.join(repoRoot, '.env')
+  if (!fs.existsSync(envPath)) return
+  const text = fs.readFileSync(envPath, 'utf8')
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const eq = trimmed.indexOf('=')
+    if (eq <= 0) continue
+    const key = trimmed.slice(0, eq).trim()
+    let value = trimmed.slice(eq + 1).trim()
+    if (
+      (value.startsWith('"') && value.endsWith('"'))
+      || (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1)
+    }
+    if (process.env[key] === undefined) process.env[key] = value
+  }
+}
+
+async function waitForHealth(timeoutMs = 60_000) {
+  const start = Date.now()
+  let lastError = ''
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(HEALTH_URL)
+      if (res.ok) return await res.json()
+      lastError = `HTTP ${res.status}`
+    }
+    catch (err) {
+      lastError = err instanceof Error ? err.message : String(err)
+    }
+    await new Promise(r => setTimeout(r, 250))
+  }
+  throw new Error(`Nitro health check timed out (${HEALTH_URL}): ${lastError}`)
+}
+
+function startNitro() {
+  if (!fs.existsSync(nitroEntry)) {
+    throw new Error(
+      `Missing ${nitroEntry}. Run \`npm run build\` before \`npm run desktop:spike\`.`,
+    )
+  }
+
+  const audioWorkDir = path.join(app.getPath('userData'), 'audio')
+  fs.mkdirSync(audioWorkDir, { recursive: true })
+
+  const env = {
+    ...process.env,
+    NODE_ENV: 'production',
+    HOST,
+    PORT: String(PORT),
+    NUXT_AUDIO_WORK_DIR: process.env.NUXT_AUDIO_WORK_DIR || audioWorkDir,
+  }
+
+  const nodeBin = process.env.npm_node_execpath || 'node'
+  nitroChild = spawn(nodeBin, [nitroEntry], {
+    cwd: repoRoot,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  const tag = '[louis-nitro]'
+  if (nitroChild.stdout) {
+    createInterface({ input: nitroChild.stdout }).on('line', line => {
+      console.log(`${tag} ${line}`)
+    })
+  }
+  if (nitroChild.stderr) {
+    createInterface({ input: nitroChild.stderr }).on('line', line => {
+      console.error(`${tag} ${line}`)
+    })
+  }
+
+  nitroChild.on('exit', (code, signal) => {
+    nitroChild = null
+    if (!quitting) {
+      console.error(`${tag} exited unexpectedly (code=${code}, signal=${signal})`)
+      app.quit()
+    }
+  })
+}
+
+function stopNitro() {
+  if (!nitroChild || nitroChild.killed) return
+  const child = nitroChild
+  nitroChild = null
+  try {
+    child.kill('SIGTERM')
+  }
+  catch {
+    // ignore
+  }
+  setTimeout(() => {
+    if (!child.killed) {
+      try {
+        child.kill('SIGKILL')
+      }
+      catch {
+        // ignore
+      }
+    }
+  }, 3000)
+}
+
+function createWindow() {
+  mainWindow = new BrowserWindow({
+    width: 1280,
+    height: 840,
+    minWidth: 360,
+    minHeight: 640,
+    title: 'Louis',
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.cjs'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  })
+
+  mainWindow.on('closed', () => {
+    mainWindow = null
+  })
+
+  return mainWindow.loadURL(BASE_URL)
+}
+
+async function boot() {
+  loadDotEnv()
+  startNitro()
+  const health = await waitForHealth()
+  console.log('[louis-desktop] health ok', {
+    ytdlp: health?.checks?.ytdlp?.available,
+    ffmpeg: health?.checks?.ffmpeg?.available,
+  })
+  await createWindow()
+}
+
+app.whenReady().then(() => {
+  boot().catch((err) => {
+    console.error('[louis-desktop] boot failed', err)
+    stopNitro()
+    app.exit(1)
+  })
+})
+
+app.on('before-quit', () => {
+  quitting = true
+  stopNitro()
+})
+
+app.on('window-all-closed', () => {
+  app.quit()
+})

--- a/desktop/preload.cjs
+++ b/desktop/preload.cjs
@@ -1,0 +1,1 @@
+// Spike preload — contextIsolation on; no Node APIs exposed to the page yet.

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -1,0 +1,99 @@
+# Desktop wrapper
+
+Louis is a **Nuxt/Nitro server** app (`node .output/server/index.mjs`) that needs **yt-dlp**, **ffmpeg**, a writable audio work dir, and Yoto/YouTube credentials. A static SPA shell cannot replace that.
+
+Docker remains the primary self-host path. Desktop is the consumer convenience track: same `.output`, no separate UI build.
+
+## Decision: Electron long-term
+
+| Option | Verdict for Louis |
+|--------|-------------------|
+| **Electron** | **Chosen track** — same Node stack as Nitro; spawn `.output/server/index.mjs`, open `BrowserWindow` |
+| Deno Desktop | Spike **passed** functionally (2026-08-06) but rejected long-term: dual runtime (Deno Node-compat over Nitro), experimental CLI, permission/`--no-check` friction |
+| Tauri 2 | Distant third — Nuxt docs push SSG; would still need a Node sidecar for Louis |
+
+### Why not Deno despite a green spike
+
+Deno Desktop auto-detects Nuxt and ran health + yt-dlp preview successfully, but Louis would ship under a second runtime forever. Electron main is Node: spawn the identical server Docker/`npm run start` already use.
+
+## Architecture
+
+```text
+Electron main
+  → spawn: node .output/server/index.mjs  (HOST=127.0.0.1 PORT=4010 …)
+  → wait:  GET /api/health
+  → BrowserWindow → http://127.0.0.1:4010/
+  → on quit: SIGTERM Nitro child
+```
+
+Spike host lives under [`desktop/`](../desktop/) (`main.mjs`, `preload.mjs`). Root script: `npm run desktop:spike`.
+
+### Spike defaults
+
+| Setting | Value |
+|---------|--------|
+| Port | **4010** (avoids clash with `npm run dev` on 4000) |
+| Audio dir | `app.getPath('userData')/audio` |
+| Secrets | Inherit process env / shell `.env` — **do not** bake into the binary |
+| yt-dlp / ffmpeg | System `PATH` for the spike |
+
+```bash
+npm run build
+npm run desktop:spike
+```
+
+## Electron spike results (2026-08-06, macOS arm64)
+
+```bash
+npm run build
+npm run desktop:spike
+```
+
+Verified against `http://127.0.0.1:4010`:
+
+- `GET /api/health` → `ok`; yt-dlp + ffmpeg **available** (system PATH); audio work dir under Electron `userData` / `Louis/audio` (after `app.setName('Louis')`)
+- `GET /` → 200
+- YouTube search API → 200
+- Preview download via yt-dlp → 200
+- Quit Electron → Nitro child gone; port **4010** clear (no orphan)
+
+Host: [`desktop/main.mjs`](../desktop/main.mjs) + [`desktop/preload.cjs`](../desktop/preload.cjs). Loads `.env` into the Electron process at runtime (not compiled into a binary).
+
+### Spike-only limits (Phase 0)
+
+- **yt-dlp / ffmpeg:** system `PATH` only (not bundled)
+- **Secrets:** repo-root `.env` at runtime — fine for maintainers; not for distribution
+- **Layout:** requires checkout + `npm run build` (`.output/`)
+- **No installers** yet — see [DESKTOP_SHIP.md](DESKTOP_SHIP.md)
+
+## Shipping yt-dlp + ffmpeg (next pass)
+
+Consumers will not have Homebrew.
+
+1. CI downloads platform binaries into e.g. `desktop/bin/<os-arch>/`.
+2. Package via Electron `extraResources` → runtime under `process.resourcesPath`.
+3. At launch set `NUXT_YTDLP_PATH` and prepend ffmpeg’s directory to `PATH` (Louis resolves `ffmpeg` via PATH in `server/utils/system-deps.ts`; yt-dlp via `NUXT_YTDLP_PATH` in `server/utils/youtube-download.ts`).
+4. `NUXT_AUDIO_WORK_DIR` stays under Electron `userData`.
+
+Alternatives: download-on-first-run into Application Support; or document system installs (devs only).
+
+## Historical: Deno Desktop probe (2026-08-06, macOS arm64)
+
+Kept for research continuity — **not** the shipping path.
+
+```bash
+npm run build
+deno desktop -A --backend webview --no-check --node-modules-dir=manual --output ./yoto-cards.app .
+```
+
+Verified: `/api/health` (yt-dlp + ffmpeg available), `/`, YouTube search, preview download. Gotchas included Deno permissions (`-A`), `--no-check` for `@types/node`, `--env-file` embedding secrets, random listen port, large `node_modules` embed, experimental CLI.
+
+## Next implementation steps
+
+Work the ordered checklist: **[DESKTOP_SHIP.md](DESKTOP_SHIP.md)** (Phases 0–7). That doc also defines how DMG/NSIS attach to the same GitHub Release as GHCR when you `npm run release`.
+
+## References
+
+- [Electron](https://www.electronjs.org/docs/latest/)
+- [Deno Desktop](https://docs.deno.com/runtime/desktop/) (rejected long-term)
+- [Deno vs Electron comparison](https://docs.deno.com/runtime/desktop/comparison/)

--- a/docs/DESKTOP_SHIP.md
+++ b/docs/DESKTOP_SHIP.md
@@ -1,0 +1,221 @@
+# Desktop ship checklist
+
+Ordered path from the Electron spike → merge → **one** GitHub Release that carries both Docker (GHCR) and desktop installers. Work **one phase per PR** when possible. Quote a single phase to spawn a Cursor sub-plan.
+
+Research background: [DESKTOP.md](DESKTOP.md). Cut releases: [RELEASE.md](RELEASE.md).
+
+## Locked defaults
+
+| Topic | Choice |
+|--------|--------|
+| First public cut | macOS (arm64 + x64) + Windows x64 |
+| Linux | Phase 7 stretch (AppImage on the same Release) |
+| Credentials | userData config + Preferences / first-run UI (never baked into the binary) |
+| Packager | electron-builder |
+| Port | `127.0.0.1:4010` |
+| Yoto redirect | `http://127.0.0.1:4010/api/yoto/auth/callback` |
+| yt-dlp / ffmpeg | Bundled via `extraResources` |
+| Publish | Same `npm run release` / `v*` tag as today — installers attach to that Release |
+
+---
+
+## Publish story (seamless)
+
+### Today (operator muscle memory — keep this)
+
+```text
+main → npm run release
+  → bump package.json + CHANGELOG
+  → tag vX.Y.Z + push
+  → release-it creates GitHub Release
+  → tag push runs .github/workflows/release.yml
+  → GHCR: :latest + :vX.Y.Z
+```
+
+### Target (one release, two channels)
+
+```text
+npm run release  →  tag vX.Y.Z  →  GitHub Release (notes)
+                         ├─ CI Docker job     → GHCR :latest + :vX.Y.Z
+                         ├─ CI Electron macOS → upload *.dmg to that Release
+                         └─ CI Electron Windows → upload Setup.exe to that Release
+```
+
+### Where users get desktop builds — the GitHub Release page
+
+For tag `v1.2.0`, open `…/releases/tag/v1.2.0`:
+
+- Release notes (CHANGELOG / release-it)
+- **Assets** (download buttons): e.g. `Louis-1.2.0-arm64.dmg`, `Louis-1.2.0-x64.dmg`, `Louis-Setup-1.2.0.exe` (later AppImage)
+- GHCR is **not** a file on that page — README links `docker pull ghcr.io/…:v1.2.0` beside “Download for Mac/Windows”
+
+**OS installers = Release Assets.** Docker = GHCR tags with the **same** `vX.Y.Z`. One Release page is the consumer front door for desktops.
+
+### How CI fills that page
+
+1. `npm run release` creates the GitHub Release for `vX.Y.Z` (notes; desktop files may arrive seconds later).
+2. Tag push runs [`.github/workflows/release.yml`](../.github/workflows/release.yml): Docker → GHCR; desktop jobs build installers and `gh release upload vX.Y.Z <files>` (or equivalent) onto **that** Release.
+3. Assets appear under the Release **Assets** list when CI finishes.
+
+### Seamlessness rules
+
+1. **One version** — `package.json` = Preferences “Louis v…” = Docker tag = installer filenames on the Release page.
+2. **One command** — maintainers only run `npm run release` on `main` (see [RELEASE.md](RELEASE.md)). No desktop-only version ritual.
+3. **One GitHub Release page** — release-it creates it; CI attaches DMG/NSIS as Assets. Workflow needs `contents: write` (today: `contents: read` + Docker only).
+4. **One workflow trigger** — extend existing `on: push: tags: v*`. No second tag scheme.
+5. **Same changelog** — desktop bullets under the same version section that backs Release notes.
+6. **Complementary channels** — Release Assets = desktop; GHCR = self-host.
+
+---
+
+## Phase 0 — Merge the spike baseline
+
+**Goal:** Land the working Electron spike on `main` without installers.
+
+**Touches:** `desktop/`, `package.json` (electron, `desktop:spike`), [DESKTOP.md](DESKTOP.md), `.gitignore`
+
+**Do:**
+
+- [x] Open PR with spike host (`desktop/main.mjs`, `preload.cjs`, README)
+- [x] Confirm `npm run build && npm run desktop:spike` on maintainer macOS
+- [x] Document spike-only limits (system PATH yt-dlp/ffmpeg, repo `.env`)
+
+**Acceptance:** Health OK, UI loads, quit leaves port 4010 clear. No electron-builder yet. _(Verified 2026-08-06 on macOS arm64.)_
+
+**Exit →** Phase 1
+
+---
+
+## Phase 1 — Production Electron host
+
+**Goal:** Packaged-ready host that runs Nitro from app resources, not only a git checkout.
+
+**Touches:** `desktop/main.mjs`, electron-builder config (early), app icons, productName
+
+**Do:**
+
+- [ ] Resolve `.output` for dev vs packaged (`app.getAppPath()` / `process.resourcesPath`)
+- [ ] Spawn Nitro with `ELECTRON_RUN_AS_NODE=1` on the Electron binary (no second Node runtime)
+- [ ] Set productName **Louis**, icons, `userData` under Louis (not “Electron”)
+- [ ] Single-instance lock; loading UI until `/api/health`; dialog if Nitro exits unexpectedly
+- [ ] Local smoke: `electron-builder --dir` (or equivalent unpackaged build) boots UI
+
+**Acceptance:** Unpackaged built app launches Louis UI without requiring the repo tree layout of a spike.
+
+**Exit →** Phase 2
+
+---
+
+## Phase 2 — Bundle yt-dlp + ffmpeg
+
+**Goal:** Consumers need no Homebrew / system ffmpeg.
+
+**Touches:** `desktop/resources/bin/<platform>/`, download script, spawn env in `desktop/main.mjs`, `server/utils/system-deps.ts` / `youtube-download.ts` (env only)
+
+**Do:**
+
+- [ ] CI/script downloads platform binaries into `desktop/resources/bin/<platform>/`
+- [ ] Ship via electron-builder `extraResources`
+- [ ] At spawn: set `NUXT_YTDLP_PATH`; prepend ffmpeg dir to `PATH`
+- [ ] Keep `NUXT_AUDIO_WORK_DIR` under Electron `userData`
+
+**Acceptance:** On a machine **without** Homebrew yt-dlp/ffmpeg, `/api/health` reports both available via bundled paths; preview download works.
+
+**Exit →** Phase 3
+
+---
+
+## Phase 3 — Credentials + OAuth
+
+**Goal:** Full connect + search without a repo-root `.env`.
+
+**Touches:** userData config JSON, Preferences / first-run UI, spawn env (`NUXT_YOTO_*`, `NUXT_YOUTUBE_API_KEY`, redirect URI)
+
+**Do:**
+
+- [ ] Persist client id + YouTube API key (and optional cookies path) under `userData`
+- [ ] Minimal first-run or Preferences fields (prefer existing Preferences patterns)
+- [ ] Always set `NUXT_YOTO_REDIRECT_URI=http://127.0.0.1:4010/api/yoto/auth/callback` when spawning Nitro
+- [ ] Document Yoto portal registration for that redirect in DESKTOP.md / README
+
+**Acceptance:** OAuth connect + YouTube search succeed with only in-app config (no checkout `.env`).
+
+**Exit →** Phase 4
+
+---
+
+## Phase 4 — Installers (electron-builder)
+
+**Goal:** Distributable DMG / NSIS that pass clean-machine smoke.
+
+**Touches:** electron-builder config, icons, signing docs
+
+**Do:**
+
+- [ ] Targets: macOS DMG (arm64 + x64), Windows NSIS x64
+- [ ] Document code signing / notarization secrets for CI (unsigned `--dir` OK for local smoke)
+- [ ] Filenames include version: `Louis-<version>-*.dmg`, `Louis-Setup-<version>.exe`
+
+**Acceptance:** Install on clean macOS + Windows VMs; app launches; Phases 2–3 still work.
+
+**Exit →** Phase 5
+
+---
+
+## Phase 5 — Release pipeline (seamless publish)
+
+**Goal:** Tag push fills the GitHub Release **Assets** list and GHCR — same ritual as today.
+
+**Touches:** [`.github/workflows/release.yml`](../.github/workflows/release.yml), [RELEASE.md](RELEASE.md), optional `npm run desktop:build`
+
+**Do:**
+
+- [ ] Keep existing Docker / GHCR job
+- [ ] Add macOS + Windows desktop jobs on `v*` tags
+- [ ] Set `permissions: contents: write` + `packages: write`
+- [ ] Upload installers to the Release for `github.ref_name` (`gh release upload` or equivalent)
+- [ ] Update RELEASE.md after-release checklist: confirm GHCR **and** Release Assets
+- [ ] Optional `desktop:build` for local/CI parity — **does not** replace `npm run release`
+
+**Acceptance:** After a `v*` tag: open `…/releases/tag/vX.Y.Z` and see DMG + NSIS under Assets; GHCR has `:vX.Y.Z` / `:latest`.
+
+**Exit →** Phase 6
+
+---
+
+## Phase 6 — Docs, changelog, merge readiness
+
+**Goal:** Ship messaging matches the dual-channel Release.
+
+**Touches:** README, CHANGELOG, DESKTOP.md, SECURITY.md as needed
+
+**Do:**
+
+- [ ] README: “Download” → latest Release Assets; “Docker” → GHCR for the same version
+- [ ] CHANGELOG Unreleased (then versioned) desktop feature bullets
+- [ ] Security: no API keys / cookies in binaries; cookies path is user-controlled
+- [ ] Mark Phases 0–5 complete in this checklist
+
+**Acceptance:** Checklist 0–5 done; docs consistent; ready for `main` + first desktop-bearing `npm run release`.
+
+**Exit →** Phase 7 (stretch) or stop at first public desktop release
+
+---
+
+## Phase 7 — Stretch (post-first-publish)
+
+**Goal:** Extra platforms / polish without changing the publish ritual.
+
+**Do:**
+
+- [ ] Linux AppImage job on the same `v*` workflow → same Release Assets list
+- [ ] Auto-update from GitHub Releases (same tags)
+- [ ] Install / first-run UX polish
+
+**Acceptance:** New assets appear on the same Release page; versioning unchanged.
+
+---
+
+## How to use this doc
+
+Each phase has **Goal**, **Touches**, **Do**, **Acceptance**, **Exit → next**. Prefer one phase per PR. Phase 5 owns the publish story; earlier phases must not invent alternate versioning or a second Releases feed.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -6,6 +6,10 @@ The app version shown in Preferences (`Louis v…`) comes from `package.json` vi
 
 Pushing a tag matching `v*` runs [`.github/workflows/release.yml`](../.github/workflows/release.yml), which publishes a Docker image to GHCR (`:latest` and `:{tag}`).
 
+### Desktop artifacts (target)
+
+Desktop installers (macOS DMG, Windows Setup) will attach as **Assets on the same GitHub Release** created by `npm run release` — same `vX.Y.Z`, no second release command. See the publish story and Phase 5 in [DESKTOP_SHIP.md](DESKTOP_SHIP.md). Until that phase lands, Releases are notes + GHCR only.
+
 ## Day to day
 
 1. Land changes on `main` through PRs as usual.
@@ -59,6 +63,7 @@ Example: splash + welcome modal + auth gate redesign → **minor** (e.g. `0.1.0`
 ## After release
 
 - Confirm the GitHub Action **Release** succeeded and the image `ghcr.io/<org>/louis:vX.Y.Z` (or your repo name) exists
+- When desktop CI is enabled ([DESKTOP_SHIP.md](DESKTOP_SHIP.md) Phase 5): confirm the Release page lists DMG / Setup.exe under **Assets**
 - Deploy that tag on Railway (or your host) when you want a pinned version; `:latest` tracks the newest tagged release
 - Start the next cycle by writing new bullets under `[Unreleased]` again
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "yoto-cards",
+  "name": "Louis",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "yoto-cards",
+      "name": "Louis",
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@release-it/keep-a-changelog": "^7.1.0",
+        "electron": "^37.10.3",
         "release-it": "^20.2.1"
       },
       "engines": {
@@ -587,6 +588,38 @@
       "resolved": "https://registry.npmjs.org/@dxup/unimport/-/unimport-0.1.2.tgz",
       "integrity": "sha512-/B8YJGPzaYq1NbsQmwgP8EZqg40NpTw4ZB3suuI0TplbxKHeK94jeaawLmVhCv+YwUnOpiWEz9U6SeThku/8JQ==",
       "license": "MIT"
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -4541,6 +4574,19 @@
       "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
       "license": "CC0-1.0"
     },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
@@ -4820,10 +4866,30 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/jsesc": {
@@ -4831,6 +4897,26 @@
       "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
       "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
       "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/parse-path": {
       "version": "7.0.3",
@@ -4844,6 +4930,27 @@
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "license": "MIT"
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@unhead/vue": {
       "version": "2.1.15",
@@ -5675,6 +5782,15 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
     },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
@@ -5821,6 +5937,51 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-api": {
@@ -5970,6 +6131,19 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cluster-key-slot": {
@@ -6402,6 +6576,35 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -6439,6 +6642,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -6449,6 +6681,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/defu": {
@@ -6520,6 +6771,14 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/devalue": {
       "version": "5.8.1",
@@ -6648,6 +6907,25 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/electron": {
+      "version": "37.10.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.10.3.tgz",
+      "integrity": "sha512-3IjCGSjQmH50IbW2PFveaTzK+KwcFX9PEhE7KXb9v5IT8cLAiryAN7qezm/XzODhDRlLu0xKG1j8xWBtZ/bx/g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^22.7.7",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.388",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.388.tgz",
@@ -6667,6 +6945,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -6694,6 +6982,16 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/error-stack-parser-es": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
@@ -6709,6 +7007,17 @@
       "integrity": "sha512-fZmsRiDNv07K6s2KkKFTiD2aIvECa7++PKyD5NC32tpRw46qZA3sOz+aM+/V9V0GDHxVTKLziveV4JhzBHDp9Q==",
       "license": "MIT"
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
@@ -6723,6 +7032,14 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
       "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
       "license": "MIT"
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -6943,6 +7260,43 @@
       "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
       "license": "MIT"
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -7008,6 +7362,16 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -7081,6 +7445,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/fsevents": {
@@ -7247,6 +7626,25 @@
         "node": ">= 6"
       }
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
     "node_modules/global-directory": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
@@ -7260,6 +7658,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/globby": {
@@ -7280,6 +7696,59 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/got/node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -7326,6 +7795,20 @@
       "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "license": "MIT"
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -7343,6 +7826,13 @@
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
       "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
       "license": "MIT"
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -7396,6 +7886,20 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -7826,6 +8330,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/json-with-bigint": {
       "version": "3.5.10",
       "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.10.tgz",
@@ -7843,6 +8362,26 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/kleur": {
@@ -8312,6 +8851,16 @@
       "integrity": "sha512-+gfBXl6sxXMPe8tKQm7qzLnUy5DUPJPKIyRHwtpCpyUEYjHYRJC/5gjUvdkuO2c3JllrPtHXH5UJJK8LRYl5yQ==",
       "license": "MIT"
     },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -8379,6 +8928,34 @@
         "@babel/parser": "^7.29.3",
         "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/matcher/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdn-data": {
@@ -8490,6 +9067,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -8853,6 +9440,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
@@ -8992,6 +9592,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
@@ -9044,6 +9655,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -9264,6 +9885,16 @@
         }
       }
     },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pac-proxy-agent": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-8.0.0.tgz",
@@ -9408,6 +10039,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/perfect-debounce": {
@@ -9953,6 +10591,16 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
@@ -10038,6 +10686,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/quansync": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
@@ -10073,6 +10732,19 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/quickjs-wasi": {
       "version": "0.0.1",
@@ -10372,6 +11044,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -10379,6 +11058,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/restore-cursor": {
@@ -10431,6 +11123,25 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/rolldown": {
@@ -10646,6 +11357,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
@@ -10670,6 +11389,37 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/serialize-javascript": {
@@ -10915,6 +11665,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
     "node_modules/srvx": {
       "version": "0.11.21",
       "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.21.tgz",
@@ -11134,6 +11892,19 @@
       },
       "peerDependencies": {
         "postcss": "^8.5.15"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
       }
     },
     "node_modules/supports-color": {
@@ -11471,6 +12242,13 @@
         "node": ">=20.18.1"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
@@ -11556,6 +12334,16 @@
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/unplugin": {
       "version": "3.3.0",
@@ -12531,6 +13319,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
@@ -12622,6 +13417,27 @@
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yauzl/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/yoctocolors": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "start": "node .output/server/index.mjs",
+    "desktop:spike": "electron desktop/main.mjs",
     "test": "node --experimental-strip-types --test shared/**/*.test.ts",
     "postinstall": "nuxt prepare",
     "release": "release-it"
@@ -32,6 +33,7 @@
   },
   "devDependencies": {
     "@release-it/keep-a-changelog": "^7.1.0",
+    "electron": "^37.10.3",
     "release-it": "^20.2.1"
   }
 }


### PR DESCRIPTION
## Summary
- Adds maintainer Electron spike (`npm run desktop:spike`) that spawns Nitro on `127.0.0.1:4010` in a BrowserWindow
- Documents research ([docs/DESKTOP.md](docs/DESKTOP.md)) and the ordered ship checklist ([docs/DESKTOP_SHIP.md](docs/DESKTOP_SHIP.md)), including how future DMG/NSIS attach to the same GitHub Release as GHCR
- Phase 0 checklist items verified on macOS (health, home 200, clean quit / port 4010 clear)

## Test plan
- [ ] `npm run build && npm run desktop:spike`
- [ ] Confirm UI loads; `curl http://127.0.0.1:4010/api/health` shows yt-dlp/ffmpeg when on PATH
- [ ] Quit the app; confirm nothing still listening on 4010
- [ ] Skim DESKTOP_SHIP.md Phase 0 (checked) and publish story


Made with [Cursor](https://cursor.com)