### PR TITLE
Desktop: default Yoto client + session fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,10 @@
 LOUIS_YOUTUBE_API_KEY=
 
 # From https://yoto.dev/get-started/start-here/
-# Create a **public** client (PKCE). Only LOUIS_YOTO_CLIENT_ID is required for self-hosting.
+# Create a **public** client (PKCE), or paste Louis's bundled public client ID below.
+# Desktop app: prefer "Use default client" in setup / Settings → Advanced (same value).
+# Only LOUIS_YOTO_CLIENT_ID is required for self-hosting — no silent fallback if empty.
+# LOUIS_YOTO_CLIENT_ID=PK00MDKCVwWvOG8o3px3qSl57FhfUZxm
 LOUIS_YOTO_CLIENT_ID=
 # Optional — only for confidential server clients (must differ from client ID).
 # Leave empty for public PKCE flow (recommended).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ How we cut releases: [docs/RELEASE.md](docs/RELEASE.md).
 
 ## [Unreleased]
 
+### Added
+- Desktop **Use default client** prefills Louis’s bundled public Yoto PKCE client ID (setup wizard + Settings → Advanced).
+
+### Fixed
+- Desktop Yoto session: expired access without refresh forces reconnect; save/reuse-test read scope from cookie or `yoto-session.json`.
+
 ## [1.1.2] - 2026-08-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Installers ship as **Assets** on each GitHub Release (same `vX.Y.Z` as Docker):
 | Windows             | `Louis-Setup-<version>.exe` |
 
 
-After install, open **Settings → Desktop API keys** and add your Yoto client ID + YouTube Data API key. Register OAuth redirect `http://127.0.0.1:4010/api/yoto/auth/callback` on [yoto.dev](https://yoto.dev/get-started/start-here/). Details: [docs/DESKTOP.md](docs/DESKTOP.md).
+After install, the setup wizard (or **Settings → Advanced**) asks for a Yoto client ID and YouTube Data API key. Prefer **Use default client** for Yoto, or bring your own from [yoto.dev](https://yoto.dev/get-started/start-here/) with redirect `http://127.0.0.1:4010/api/yoto/auth/callback`. Details: [docs/DESKTOP.md](docs/DESKTOP.md).
 
 Installers are currently **unsigned** (Gatekeeper / SmartScreen may warn). Signing notes: [docs/DESKTOP_SIGNING.md](docs/DESKTOP_SIGNING.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,7 +23,7 @@ Include:
 - Self-hosters must use HTTPS in production
 - Do not commit `.env`, API keys, refresh tokens, or YouTube `cookies.txt`
 - `LOUIS_YTDLP_COOKIES_FILE` (when set on any deploy) is a server secret — never expose path or contents via debug routes or API responses; prefer a throwaway Google account
-- **Desktop installers** do not embed Yoto/YouTube API keys or cookies. Credentials live in user-writable app data (`config.json` under Application Support / equivalent) via Settings. Optional yt-dlp cookies are a **user-chosen file path**, never shipped inside the DMG/NSIS
+- Louis builds may include a **public** Yoto PKCE client ID (not a secret). Desktop setup / Settings can prefill it via **Use default client**. Self-host still requires an explicit `LOUIS_YOTO_CLIENT_ID` in `.env` (no silent fallback). Do **not** embed YouTube API keys, client secrets, cookies, or OAuth tokens in installers or images — those live in user-writable app data (`config.json` / env) only. Optional yt-dlp cookies are a **user-chosen file path**, never shipped inside the DMG/NSIS
 - Treat unsigned desktop builds like any other downloaded binary until release signing is enabled ([docs/DESKTOP_SIGNING.md](docs/DESKTOP_SIGNING.md))
 
 ## Out of scope

--- a/app/assets/css/preferences.css
+++ b/app/assets/css/preferences.css
@@ -374,16 +374,16 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  width: 1.35rem;
-  height: 1.35rem;
+  width: 1.1rem;
+  height: 1.1rem;
   margin: 0;
   padding: 0;
-  border: 2px solid var(--color-maru-black);
+  border: 1.5px solid var(--color-maru-black);
   border-radius: 999px;
   background: var(--color-maru-white);
-  box-shadow: 2px 2px 0 var(--color-maru-black);
+  box-shadow: 1.5px 1.5px 0 var(--color-maru-black);
   font-family: var(--font-maru);
-  font-size: var(--text-maru-meta);
+  font-size: 0.65rem;
   font-weight: 700;
   line-height: 1;
   color: var(--color-maru-black);
@@ -396,7 +396,7 @@
 
 .prefs-projector__help:hover:not(:disabled) {
   background: var(--color-maru-yellow);
-  box-shadow: 3px 3px 0 var(--color-maru-black);
+  box-shadow: 2.5px 2.5px 0 var(--color-maru-black);
   translate: -1px -1px;
 }
 
@@ -687,6 +687,7 @@
 }
 
 .prefs-projector__done:disabled,
+.prefs-projector__browse:disabled,
 .prefs-projector__pull:disabled {
   opacity: 0.45;
   cursor: not-allowed;
@@ -804,6 +805,11 @@
     box-shadow 0.15s ease-out,
     translate 0.15s ease-out,
     scale 0.15s ease-out;
+}
+
+.prefs-projector__use-default {
+  align-self: flex-start;
+  margin-top: 0.5rem;
 }
 
 .prefs-projector__browse .maru-button__label,

--- a/app/assets/css/splash.css
+++ b/app/assets/css/splash.css
@@ -237,8 +237,13 @@
   gap: 0.75rem;
 }
 
+.desktop-setup__use-default {
+  margin-top: 0;
+}
+
 .desktop-setup__back {
   margin: 0;
+  margin-right: auto;
   padding: 0.35rem 0.15rem;
   border: 0;
   background: transparent;

--- a/app/components/desktop/DesktopApiKeysFields.vue
+++ b/app/components/desktop/DesktopApiKeysFields.vue
@@ -18,6 +18,8 @@ const props = withDefaults(defineProps<{
   animateIn?: boolean
   /** Show a single field (wizard step). Omit to show all. */
   only?: 'yoto' | 'youtube' | 'cookies' | 'redirect' | null
+  /** Wizard: draft matches Louis bundled client (redirect hint). */
+  usingBundledClient?: boolean
 }>(), {
   disabled: false,
   idPrefix: 'desktop-api',
@@ -25,18 +27,20 @@ const props = withDefaults(defineProps<{
   stagger: false,
   animateIn: false,
   only: null,
+  usingBundledClient: false,
 })
 
 const yotoClientId = defineModel<string>('yotoClientId', { default: '' })
 const youtubeApiKey = defineModel<string>('youtubeApiKey', { default: '' })
 const ytdlpCookiesFile = defineModel<string>('ytdlpCookiesFile', { default: '' })
 
-const { pickCookiesFile } = useDesktopHost()
+const { pickCookiesFile, getConfig } = useDesktopHost()
 const { playEvent } = useUiSound()
 
 const prefersReducedMotion = ref(false)
 const entered = ref(false)
 const redirectCopied = ref(false)
+const bundledYotoClientId = ref('')
 let redirectCopiedTimer: ReturnType<typeof setTimeout> | null = null
 let focusTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -50,6 +54,11 @@ const youtubeId = computed(() => `${props.idPrefix}-youtube-api-key`)
 const cookiesId = computed(() => `${props.idPrefix}-ytdlp-cookies`)
 
 const redirectCopyLabel = computed(() => (redirectCopied.value ? 'Copied' : 'Copy'))
+
+const showUseDefaultClient = computed(() => Boolean(bundledYotoClientId.value))
+const usingBundledClient = computed(
+  () => showUseDefaultClient.value && yotoClientId.value.trim() === bundledYotoClientId.value,
+)
 
 function showField(id: 'yoto' | 'youtube' | 'cookies' | 'redirect') {
   return !props.only || props.only === id
@@ -139,6 +148,22 @@ async function onPickCookies() {
   if (picked) ytdlpCookiesFile.value = picked
 }
 
+function onUseDefaultClient() {
+  if (props.disabled || !bundledYotoClientId.value || usingBundledClient.value) return
+  playEvent('select')
+  yotoClientId.value = bundledYotoClientId.value
+}
+
+async function loadBundledClientId() {
+  try {
+    const config = await getConfig()
+    bundledYotoClientId.value = config.bundledYotoClientId.trim()
+  }
+  catch {
+    bundledYotoClientId.value = ''
+  }
+}
+
 onMounted(() => {
   prefersReducedMotion.value = window.matchMedia('(prefers-reduced-motion: reduce)').matches
   if (props.animateIn) {
@@ -150,6 +175,7 @@ onMounted(() => {
     entered.value = true
   }
   scheduleFocus()
+  void loadBundledClientId()
 })
 
 onUnmounted(() => {
@@ -184,7 +210,10 @@ watch(
       :style="fieldsetStyle(0)"
     >
       <div class="prefs-projector__field">
-        <div class="prefs-projector__label-row">
+        <div
+          v-if="!only"
+          class="prefs-projector__label-row"
+        >
           <label
             class="prefs-projector__label"
             :for="yotoId"
@@ -210,10 +239,27 @@ watch(
           autocomplete="off"
           spellcheck="false"
           :disabled="disabled"
+          :aria-label="only ? 'Yoto client ID' : undefined"
           placeholder="Public PKCE client from yoto.dev"
         >
+        <button
+          v-if="showUseDefaultClient && !only"
+          type="button"
+          class="prefs-projector__browse prefs-projector__use-default maru-button"
+          :disabled="disabled || usingBundledClient"
+          :aria-pressed="usingBundledClient"
+          @click="onUseDefaultClient"
+        >
+          <span class="maru-button__label">{{ usingBundledClient ? 'Using default client' : 'Use default client' }}</span>
+        </button>
         <p class="prefs-projector__hint">
-          Create a <strong>public</strong> (PKCE) app at
+          <template v-if="only === 'yoto'">
+            Required to connect your Yoto account. Use Louis’s default client, or create your own
+          </template>
+          <template v-else>
+            Prefer Louis’s bundled public client, or create your own
+          </template>
+          <strong>public</strong> (PKCE) app at
           <a
             class="prefs-projector__hint-link"
             :href="YOTO_DEV_URL"
@@ -231,7 +277,10 @@ watch(
       :style="fieldsetStyle(1)"
     >
       <div class="prefs-projector__field">
-        <div class="prefs-projector__label-row">
+        <div
+          v-if="!only"
+          class="prefs-projector__label-row"
+        >
           <label
             class="prefs-projector__label"
             :for="youtubeId"
@@ -257,9 +306,11 @@ watch(
           autocomplete="off"
           spellcheck="false"
           :disabled="disabled"
+          :aria-label="only ? 'YouTube Data API key' : undefined"
           placeholder="Google Cloud Console key"
         >
         <p class="prefs-projector__hint">
+          <template v-if="only === 'youtube'">Required to search YouTube from Louis. </template>
           Enable YouTube Data API v3 in
           <a
             class="prefs-projector__hint-link"
@@ -278,7 +329,10 @@ watch(
       :style="fieldsetStyle(2)"
     >
       <div class="prefs-projector__field">
-        <div class="prefs-projector__label-row">
+        <div
+          v-if="!only"
+          class="prefs-projector__label-row"
+        >
           <label
             class="prefs-projector__label"
             :for="cookiesId"
@@ -305,6 +359,7 @@ watch(
             autocomplete="off"
             spellcheck="false"
             :disabled="disabled"
+            :aria-label="only ? 'yt-dlp cookies.txt (optional)' : undefined"
             placeholder="/path/to/cookies.txt"
           >
           <button
@@ -335,7 +390,10 @@ watch(
       :style="fieldsetStyle(3)"
     >
       <div class="prefs-projector__field">
-        <div class="prefs-projector__label-row">
+        <div
+          v-if="!only"
+          class="prefs-projector__label-row"
+        >
           <span class="prefs-projector__label">OAuth redirect URI</span>
           <MaruTooltip
             placement="bottom"
@@ -349,7 +407,10 @@ watch(
             >?</button>
           </MaruTooltip>
         </div>
-        <div class="prefs-projector__code-row">
+        <div
+          class="prefs-projector__code-row"
+          :aria-label="only ? 'OAuth redirect URI' : undefined"
+        >
           <code class="prefs-projector__code font-maru-mono">{{ redirectUri }}</code>
           <button
             ref="redirectCopyEl"
@@ -371,14 +432,25 @@ watch(
           </button>
         </div>
         <p class="prefs-projector__hint">
-          Add this exact URI on your Yoto developer app at
+          <template v-if="only === 'redirect' && usingBundledClient">
+            Already registered on Louis’s Yoto app. Copy it if you want to verify at
+          </template>
+          <template v-else-if="only === 'redirect'">
+            Register this exact URI on your Yoto developer app at
+          </template>
+          <template v-else>
+            Add this exact URI on your Yoto developer app at
+          </template>
           <a
             class="prefs-projector__hint-link"
             :href="YOTO_DEV_URL"
             target="_blank"
             rel="noopener noreferrer"
           >yoto.dev</a>
-          (port <span class="font-maru-mono">4010</span>, host <span class="font-maru-mono">127.0.0.1</span>).
+          <template v-if="only === 'redirect' && usingBundledClient">.</template>
+          <template v-else>
+            (port <span class="font-maru-mono">4010</span>, host <span class="font-maru-mono">127.0.0.1</span>).
+          </template>
         </p>
       </div>
     </div>

--- a/app/components/splash/DesktopSetupScreen.vue
+++ b/app/components/splash/DesktopSetupScreen.vue
@@ -5,9 +5,7 @@ import { colorForIndex } from '~/utils/howtoBeats'
 
 type SetupStep = 'intro' | 'yoto' | 'youtube' | 'redirect' | 'ready'
 
-const STEPS: SetupStep[] = ['intro', 'yoto', 'youtube', 'redirect', 'ready']
-/** Form field steps after intro (excludes ready confirm). */
-const FIELD_TOTAL = 3
+const ALL_STEPS: SetupStep[] = ['intro', 'yoto', 'youtube', 'redirect', 'ready']
 const FLIP_MS = 340
 const FLIP_EASE = 'cubic-bezier(0.2, 0, 0, 1)'
 const LEAVE_MS = 320
@@ -23,6 +21,7 @@ const { playEvent } = useUiSound()
 const yotoClientId = ref('')
 const youtubeApiKey = ref('')
 const redirectUri = ref('http://127.0.0.1:4010/api/yoto/auth/callback')
+const bundledYotoClientId = ref('')
 const saving = ref(false)
 const leaving = ref(false)
 const error = ref('')
@@ -38,13 +37,28 @@ const ledeEl = ref<HTMLElement | null>(null)
 const actionsEl = ref<HTMLElement | null>(null)
 const confirmEl = ref<HTMLButtonElement | null>(null)
 
-const step = computed(() => STEPS[stepIndex.value] ?? 'intro')
+const usingBundledClient = computed(
+  () => Boolean(bundledYotoClientId.value)
+    && yotoClientId.value.trim() === bundledYotoClientId.value,
+)
+
+/** Default client already has the desktop redirect registered — skip that step. */
+const activeSteps = computed(() => (
+  usingBundledClient.value
+    ? ALL_STEPS.filter(s => s !== 'redirect')
+    : ALL_STEPS
+))
+
+/** Form field steps after intro (excludes ready confirm). */
+const fieldTotal = computed(() => (usingBundledClient.value ? 2 : 3))
+
+const step = computed(() => activeSteps.value[stepIndex.value] ?? 'intro')
 const isFirst = computed(() => stepIndex.value === 0)
-const isLast = computed(() => stepIndex.value === STEPS.length - 1)
+const isLast = computed(() => stepIndex.value === activeSteps.value.length - 1)
 const isReadyStep = computed(() => step.value === 'ready')
 
-/** Progress through form fields; intro is 0; ready stays at FIELD_TOTAL. */
-const fieldsDone = computed(() => Math.min(stepIndex.value, FIELD_TOTAL))
+/** Progress through form fields; intro is 0; ready stays at fieldTotal. */
+const fieldsDone = computed(() => Math.min(stepIndex.value, fieldTotal.value))
 
 const stepCountColor = computed(() => colorForIndex(fieldsDone.value))
 
@@ -52,6 +66,10 @@ const fieldOnly = computed((): 'yoto' | 'youtube' | 'redirect' | null => {
   if (step.value === 'intro' || step.value === 'ready') return null
   return step.value
 })
+
+const showUseDefaultClient = computed(
+  () => step.value === 'yoto' && Boolean(bundledYotoClientId.value),
+)
 
 const canAdvance = computed(() => {
   if (saving.value || leaving.value) return false
@@ -87,21 +105,18 @@ const heading = computed(() => {
 const lede = computed(() => {
   switch (step.value) {
     case 'intro':
-      return 'A few keys so Louis can talk to Yoto and YouTube. They stay on this computer — never inside the app installer.'
-    case 'yoto':
-      return 'Required to connect your Yoto account.'
-    case 'youtube':
-      return 'Required to search YouTube from Louis.'
-    case 'redirect':
-      return 'Register this exact URI on your Yoto developer app at yoto.dev.'
+      return 'A few keys so Louis can talk to Yoto and YouTube. Your YouTube key stays on this computer — use Louis’s bundled Yoto client or your own.'
     case 'ready':
       return desktopPrefsDebug.value
-        ? 'Keys stay on this computer. Confirm to open Louis and connect to Yoto.'
-        : 'Keys stay on this computer. Confirm to save, restart the local server, and connect to Yoto.'
+        ? 'Your YouTube key stays on this computer. Confirm to open Louis and connect to Yoto.'
+        : 'Your YouTube key stays on this computer. Confirm to save, restart the local server, and connect to Yoto.'
     default:
+      // Field steps fold this into DesktopApiKeysFields hints.
       return ''
   }
 })
+
+const showHeaderLede = computed(() => Boolean(lede.value))
 
 function sharedEls(): HTMLElement[] {
   return [brandEl.value, titleEl.value, ledeEl.value, actionsEl.value].filter(
@@ -145,7 +160,7 @@ async function moveToStep(nextIndex: number) {
   await nextTick()
   await nextTick()
   flipFrom(sharedEls(), first)
-  if (STEPS[nextIndex] === 'ready') {
+  if (activeSteps.value[nextIndex] === 'ready') {
     await nextTick()
     confirmEl.value?.focus({ preventScroll: true })
   }
@@ -185,6 +200,7 @@ async function load() {
     const [config, uri] = await Promise.all([getConfig(), getRedirectUri()])
     yotoClientId.value = config.yotoClientId
     youtubeApiKey.value = config.youtubeApiKey
+    bundledYotoClientId.value = config.bundledYotoClientId
     redirectUri.value = uri
   }
   catch (err) {
@@ -201,6 +217,12 @@ async function goBack() {
   error.value = ''
   playEvent('buttonClick')
   await moveToStep(stepIndex.value - 1)
+}
+
+function onUseDefaultClient() {
+  if (saving.value || leaving.value || !bundledYotoClientId.value || usingBundledClient.value) return
+  playEvent('select')
+  yotoClientId.value = bundledYotoClientId.value
 }
 
 async function goNext() {
@@ -290,15 +312,16 @@ onMounted(() => {
               class="desktop-setup__step-count"
               :class="[stepCountColor.bg, stepCountColor.text]"
               aria-live="polite"
-              :aria-label="`${fieldsDone} of ${FIELD_TOTAL} fields`"
+              :aria-label="`${fieldsDone} of ${fieldTotal} fields`"
             >
               <span class="desktop-setup__step-n" aria-hidden="true">{{ fieldsDone }}</span>
               <span class="desktop-setup__step-sep" aria-hidden="true">of</span>
-              <span class="desktop-setup__step-x" aria-hidden="true">{{ FIELD_TOTAL }}</span>
+              <span class="desktop-setup__step-x" aria-hidden="true">{{ fieldTotal }}</span>
             </p>
           </Transition>
         </div>
         <p
+          v-if="showHeaderLede"
           ref="ledeEl"
           class="desktop-setup__lede prefs-projector__hint"
         >
@@ -317,6 +340,7 @@ onMounted(() => {
           id-prefix="desktop-setup"
           :error="error"
           :only="fieldOnly"
+          :using-bundled-client="usingBundledClient"
           stagger
           animate-in
         />
@@ -347,6 +371,16 @@ onMounted(() => {
             @click="goBack"
           >
             ← Back
+          </button>
+          <button
+            v-if="showUseDefaultClient"
+            type="button"
+            class="prefs-projector__done desktop-setup__use-default maru-button bg-maru-blue-light"
+            :disabled="saving || leaving || usingBundledClient"
+            :aria-pressed="usingBundledClient"
+            @click="onUseDefaultClient"
+          >
+            <span class="maru-button__label">{{ usingBundledClient ? 'Using default client' : 'Use default client' }}</span>
           </button>
           <button
             ref="confirmEl"

--- a/app/components/youtube-picker/EmptyStateHowto.vue
+++ b/app/components/youtube-picker/EmptyStateHowto.vue
@@ -427,7 +427,7 @@ function onKeydown(event: KeyboardEvent) {
   --howto-fan-max-w: 25rem;
   --howto-fan-max-h: 18rem;
   /* Extra overall shrink — height (and width) without retuning type/geometry. */
-  --howto-fan-shrink: 1;
+  --howto-fan-shrink: 0.9;
 }
 
 /* Mid / tall panes: let the fan use the cell — only the available box should clip it. */

--- a/app/composables/useDesktopHost.ts
+++ b/app/composables/useDesktopHost.ts
@@ -1,14 +1,18 @@
+import { BUNDLED_YOTO_CLIENT_ID } from '#shared/bundledYotoClientId.mjs'
+
 export type LouisDesktopConfig = {
   yotoClientId: string
   yotoClientSecret: string
   youtubeApiKey: string
   ytdlpCookiesFile: string
+  /** Louis public PKCE client ID for “Use default client” (not persisted). */
+  bundledYotoClientId: string
 }
 
 type LouisDesktopBridge = {
   isDesktop: true
-  getConfig: () => Promise<LouisDesktopConfig>
-  setConfig: (config: Partial<LouisDesktopConfig>) => Promise<LouisDesktopConfig>
+  getConfig: () => Promise<Partial<LouisDesktopConfig>>
+  setConfig: (config: Partial<LouisDesktopConfig>) => Promise<Partial<LouisDesktopConfig>>
   pickCookiesFile: () => Promise<string | null>
   getRedirectUri: () => Promise<string>
   openExternal: (url: string) => Promise<void>
@@ -30,6 +34,7 @@ function emptyConfig(): LouisDesktopConfig {
     yotoClientSecret: '',
     youtubeApiKey: '',
     ytdlpCookiesFile: '',
+    bundledYotoClientId: BUNDLED_YOTO_CLIENT_ID,
   }
 }
 
@@ -39,6 +44,18 @@ function normalizeConfig(raw: Partial<LouisDesktopConfig> | null | undefined): L
     yotoClientSecret: String(raw?.yotoClientSecret || '').trim(),
     youtubeApiKey: String(raw?.youtubeApiKey || '').trim(),
     ytdlpCookiesFile: String(raw?.ytdlpCookiesFile || '').trim(),
+    bundledYotoClientId:
+      String(raw?.bundledYotoClientId || '').trim() || BUNDLED_YOTO_CLIENT_ID,
+  }
+}
+
+/** Persist only user credentials in the prefs mock (not bundled metadata). */
+function mockPersistShape(config: LouisDesktopConfig) {
+  return {
+    yotoClientId: config.yotoClientId,
+    yotoClientSecret: config.yotoClientSecret,
+    youtubeApiKey: config.youtubeApiKey,
+    ytdlpCookiesFile: config.ytdlpCookiesFile,
   }
 }
 
@@ -57,7 +74,7 @@ function readMockConfig(): LouisDesktopConfig {
 function writeMockConfig(next: LouisDesktopConfig): LouisDesktopConfig {
   const normalized = normalizeConfig(next)
   if (typeof sessionStorage !== 'undefined') {
-    sessionStorage.setItem(DESKTOP_PREFS_MOCK_CONFIG_KEY, JSON.stringify(normalized))
+    sessionStorage.setItem(DESKTOP_PREFS_MOCK_CONFIG_KEY, JSON.stringify(mockPersistShape(normalized)))
   }
   return normalized
 }
@@ -138,7 +155,7 @@ export function useDesktopHost() {
     }
     if (window.louisDesktop) {
       const raw = await window.louisDesktop.setConfig(config)
-      return normalizeConfig(raw)
+      return normalizeConfig({ ...raw, bundledYotoClientId: BUNDLED_YOTO_CLIENT_ID })
     }
     if (desktopPrefsDebug.value) {
       const current = readMockConfig()

--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -13,6 +13,7 @@ import {
   effectiveDesktopConfig,
   mergeDesktopConfig,
 } from './configStore.mjs'
+import { BUNDLED_YOTO_CLIENT_ID } from '../shared/bundledYotoClientId.mjs'
 import { pickLouisEnv, setLouisAndNuxtEnv } from '../shared/louis-env.mjs'
 
 const require = createRequire(import.meta.url)
@@ -364,7 +365,11 @@ async function showLoadingThenApp() {
 
 function registerIpc() {
   // Return effective config so empty config.json + spike .env matches setup gating.
-  ipcMain.handle('louis:get-config', () => effectiveConfigForSetupCheck())
+  // bundledYotoClientId is UI metadata only (not persisted to config.json).
+  ipcMain.handle('louis:get-config', () => ({
+    ...effectiveConfigForSetupCheck(),
+    bundledYotoClientId: BUNDLED_YOTO_CLIENT_ID,
+  }))
   ipcMain.handle('louis:get-redirect-uri', () => DESKTOP_REDIRECT_URI)
 
   ipcMain.handle('louis:open-external', async (_event, url) => {

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -24,14 +24,18 @@ Builds are currently **unsigned**. macOS Gatekeeper or Windows SmartScreen may w
 
 On first launch (or whenever required keys are missing), Louis plays the splash, then walks through a **setup wizard** on the same background — one question at a time. Use **Back** to go to the previous step. The last screen confirms you’re ready; **Let’s go** saves and opens the app. The main app stays blocked until you finish.
 
-### 1. Yoto developer app
+### 1. Yoto client
+
+Prefer **Use default client** in the setup wizard (or later under **Settings → Advanced**). That prefills Louis’s bundled public PKCE client ID — the desktop redirect URI is already registered on Louis’s Yoto app.
+
+To bring your own instead:
 
 1. Create a **public** (PKCE) client at [yoto.dev](https://yoto.dev/get-started/start-here/).
 2. Register this redirect URI **exactly**:
 
    `http://127.0.0.1:4010/api/yoto/auth/callback`
 
-3. Paste the **client ID** into the setup form. Leave the client secret empty (public PKCE).
+3. Paste the **client ID** into the setup form (or Settings). Leave the client secret empty (public PKCE).
 
 ### 2. YouTube Data API
 
@@ -39,15 +43,15 @@ Enable **YouTube Data API v3** in Google Cloud Console, create an API key, and p
 
 ### 3. Ready
 
-After the redirect URI step, confirm you’re ready. Press **Let’s go** — Louis saves keys to app data and restarts the local server (in the desktop app). Then use **Connect** to sign in with Yoto — Louis opens your **system browser** (password managers work; a bad client ID leaves Louis usable so you can fix Settings).
+If you used Louis’s default client, the wizard skips the OAuth redirect step (already registered). With your own client, you’ll see the redirect URI to register first. Then confirm you’re ready and press **Let’s go** — Louis saves keys to app data and restarts the local server (in the desktop app). Then use **Connect** to sign in with Yoto — Louis opens your **system browser** (password managers work; a bad client ID leaves Louis usable so you can fix Settings).
 
-You can change keys later under **Settings → Advanced**.
+You can change keys later under **Settings → Advanced** (including switching between Louis’s default Yoto client and your own).
 
 ### Optional: yt-dlp cookies
 
 Not part of first-run setup. If YouTube blocks anonymous downloads (bot check / age gate), open **Settings → Advanced** and set a Netscape `cookies.txt` path (throwaway Google account preferred; never share or commit that file).
 
-Keys are **not** stored inside the installer. They live only in your user data folder (see below).
+Louis may ship its **public** Yoto PKCE client ID inside the app. Your **YouTube API key**, OAuth tokens, and cookies stay only in your user data folder (see below) — never baked into the installer as secrets.
 
 ## Using the app
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -30,6 +30,10 @@
     {
       "from": "shared/louis-env.mjs",
       "to": "shared/louis-env.mjs"
+    },
+    {
+      "from": "shared/bundledYotoClientId.mjs",
+      "to": "shared/bundledYotoClientId.mjs"
     }
   ],
   "asar": true,

--- a/server/api/yoto/content/[cardId]/reuse-test.post.ts
+++ b/server/api/yoto/content/[cardId]/reuse-test.post.ts
@@ -1,6 +1,6 @@
 import { testReuseContentUpdate } from '../../../../utils/save-jobs'
-import { getScopeCookie, hasContentManageScope } from '../../../../utils/yoto-auth'
-import { getYotoAccessToken } from '../../../../utils/yoto'
+import { hasContentManageScope } from '../../../../utils/yoto-auth'
+import { getYotoAccessToken, getYotoAuthScope } from '../../../../utils/yoto'
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig(event)
@@ -13,7 +13,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'cardId is required' })
   }
 
-  const scope = getScopeCookie(event)
+  const scope = getYotoAuthScope(event)
   if (!hasContentManageScope(scope)) {
     throw createError({
       statusCode: 403,

--- a/server/api/yoto/content/[cardId]/save.post.ts
+++ b/server/api/yoto/content/[cardId]/save.post.ts
@@ -1,6 +1,6 @@
-import { getScopeCookie, hasContentManageScope } from '../../../../utils/yoto-auth'
+import { hasContentManageScope } from '../../../../utils/yoto-auth'
 import { startSaveJob } from '../../../../utils/save-jobs'
-import { getYotoAccessToken } from '../../../../utils/yoto'
+import { getYotoAccessToken, getYotoAuthScope } from '../../../../utils/yoto'
 import type { PlaylistTrack } from '#shared/myo-editor/types'
 
 interface SaveRequestBody {
@@ -17,7 +17,8 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'cardId is required' })
   }
 
-  const scope = getScopeCookie(event)
+  // Desktop system-browser OAuth stores scope in yoto-session.json, not cookies.
+  const scope = getYotoAuthScope(event)
   if (!hasContentManageScope(scope)) {
     throw createError({
       statusCode: 403,

--- a/server/utils/yoto.ts
+++ b/server/utils/yoto.ts
@@ -49,10 +49,16 @@ export function isYotoConfigured(event: H3Event): boolean {
   return Boolean(config.yotoClientId)
 }
 
+/** True when we can still obtain an API access token (refresh or non-expired access). */
 export function isYotoConnected(event: H3Event): boolean {
-  if (getRefreshTokenCookie(event) || getAccessTokenCookie(event)) return true
+  if (getRefreshTokenCookie(event)) return true
+  if (getAccessTokenCookie(event)) return true
   const session = readYotoDesktopSession()
-  return Boolean(session?.refreshToken || session?.accessToken)
+  if (!session) return false
+  if (session.refreshToken) return true
+  if (!session.accessToken) return false
+  if (session.accessExpiresAt && Date.now() > session.accessExpiresAt) return false
+  return true
 }
 
 export function getYotoAuthScope(event: H3Event): string | undefined {
@@ -61,7 +67,11 @@ export function getYotoAuthScope(event: H3Event): string | undefined {
 
 export async function getYotoAccessToken(event: H3Event): Promise<string> {
   const config = getYotoConfig(event)
-  const refreshToken = getRefreshTokenCookie(event) || readYotoDesktopSession()?.refreshToken || ''
+  const session = readYotoDesktopSession()
+  const refreshToken = getRefreshTokenCookie(event) || session?.refreshToken || ''
+  const cookieAccess = getAccessTokenCookie(event) || ''
+  const sessionAccess = session?.accessToken || ''
+  const sessionExpired = Boolean(session?.accessExpiresAt && Date.now() > session.accessExpiresAt)
 
   if (refreshToken) {
     try {
@@ -99,7 +109,16 @@ export async function getYotoAccessToken(event: H3Event): Promise<string> {
     }
   }
 
-  const accessToken = getAccessTokenCookie(event) || readYotoDesktopSession()?.accessToken || ''
+  // Expired desktop access with no refresh → force reconnect (do not call Yoto with a dead token).
+  if (sessionAccess && sessionExpired) {
+    clearYotoDesktopSession()
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'Yoto session expired. Please reconnect.',
+    })
+  }
+
+  const accessToken = cookieAccess || sessionAccess
   if (accessToken) {
     return accessToken
   }

--- a/shared/bundledYotoClientId.mjs
+++ b/shared/bundledYotoClientId.mjs
@@ -1,0 +1,6 @@
+/**
+ * Louis's public Yoto PKCE client ID — safe to ship in all builds (not a secret).
+ * Desktop "Use default client" prefills this; self-hosters can paste it into LOUIS_YOTO_CLIENT_ID.
+ * Runtime OAuth still requires an explicit config.json / env value (no silent fallback).
+ */
+export const BUNDLED_YOTO_CLIENT_ID = 'PK00MDKCVwWvOG8o3px3qSl57FhfUZxm'

--- a/shared/bundledYotoClientId.test.ts
+++ b/shared/bundledYotoClientId.test.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { BUNDLED_YOTO_CLIENT_ID } from './bundledYotoClientId.mjs'
+
+describe('BUNDLED_YOTO_CLIENT_ID', () => {
+  it('exports a non-empty public PKCE client id string', () => {
+    assert.equal(typeof BUNDLED_YOTO_CLIENT_ID, 'string')
+    assert.ok(BUNDLED_YOTO_CLIENT_ID.trim().length > 0)
+    assert.equal(BUNDLED_YOTO_CLIENT_ID, BUNDLED_YOTO_CLIENT_ID.trim())
+  })
+})


### PR DESCRIPTION
## Summary
- Prefill Louis’s bundled public Yoto PKCE client via **Use default client** (setup wizard + Settings → Advanced); ship ID in desktop package.
- Fix desktop OAuth: expired access without refresh forces reconnect; save/reuse-test read scope from cookie or `yoto-session.json`.
- Minor howto fan shrink polish.

## Test plan
- [ ] Desktop spike / prefs mock: `?desktopPrefs=1&desktopSetup=1` — **Use default client** prefills ID; wizard can skip redirect when default used
- [ ] Settings → Advanced: default client button + disabled “Using default client” state
- [ ] After Connect with system browser: save / reuse-test work with scope from session file
- [ ] Expire/remove refresh in `yoto-session.json` with dead access → reconnect (401), not fake “scopes” 403
- [ ] `npm test` (includes `bundledYotoClientId` test)


Made with [Cursor](https://cursor.com)